### PR TITLE
harden: fix parser stack-overflow DoS, cache correctness, and performance

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,3 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
+      # Verify the no_std build via the rlib crate-type; a bare
+      # `cargo check --no-default-features` would try to link the cdylib and
+      # fail for lack of a downstream-provided allocator / panic handler.
+      - name: no_std (rlib) build check
+        run: cargo rustc --no-default-features --features sem_arith --crate-type rlib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "toml",
  "wasm-bindgen",
 ]
@@ -564,10 +564,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ serde = { version = "^1", default-features = false, features = [
     "alloc",
 ] }
 serde_json = { version = "^1", optional = true }
-serde_yaml = { version = "^0.9", optional = true }
+# serde_yaml 0.9 is unmaintained (RUSTSEC-2024-0320); use the maintained
+# drop-in fork under the original crate name so downstream code is unchanged.
+serde_yaml = { package = "serde_yaml_ng", version = "^0.10", optional = true }
 toml = { version = "^0.8", optional = true }
 once_cell = { version = "1", optional = true }
 hashbrown = { version = "0.15", features = ["serde"] }

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,14 @@ CARGO_FUZZ ?= cargo fuzz
 DICT_ARG = $(if $(filter $(TARGET),$(DICT_TARGETS)),-dict="$(DICT)",)
 FUZZ_ARGS = -artifact_prefix="$(ARTIFACT_PREFIX)" -max_total_time=$(MAX_TIME) $(DICT_ARG) $(RUN_ARGS)
 
-.PHONY: clean help check test fmt fmt-check clippy bench run fuzz fuzz-all fuzz-quick fuzz-check fuzz-install fuzz-clean fuzz-list fuzz-replay validate-fuzz-target wasm ffi python
+.PHONY: clean help check check-nostd test fmt fmt-check clippy bench run fuzz fuzz-all fuzz-quick fuzz-check fuzz-install fuzz-clean fuzz-list fuzz-replay validate-fuzz-target wasm ffi python
 
 help:
 	@printf '%s\n' \
 		'Usage:' \
 		'  make all' \
 		'  make check' \
+		'  make check-nostd' \
 		'  make clean' \
 		'  make test' \
 		'  make fmt' \
@@ -37,6 +38,7 @@ help:
 		'Targets:' \
 		'  help         Show this message' \
 		'  check        cargo check --features all' \
+		'  check-nostd  no_std rlib build check (no default features)' \
 		'  clean        cargo clean plus fuzz outputs' \
 		'  test         cargo test --features all -- --nocapture' \
 		'  fmt          cargo fmt' \
@@ -68,6 +70,13 @@ help:
 
 check:
 	$(CARGO) check --features all
+
+# no_std is consumed as an rlib (the downstream binary supplies the global
+# allocator / panic handler). A bare `cargo check --no-default-features` would
+# instead try to link the cdylib artifact and fail for lack of those, so verify
+# no_std against the rlib crate-type.
+check-nostd:
+	$(CARGO) rustc --no-default-features --features sem_arith --crate-type rlib
 
 test:
 	$(CARGO) test --features all -- --nocapture

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,7 +8,7 @@ use crate::{
     val::Val,
 };
 
-const MAX_PARSE_DEPTH: usize = 128;
+pub(crate) const MAX_PARSE_DEPTH: usize = 128;
 const MAX_AT_PATH_SEGMENTS: usize = 256;
 static NIL_TOKEN: Token = Token::Nil;
 
@@ -186,60 +186,69 @@ impl<'a> Parser<'a> {
     fn parse_coalesce(&mut self) -> Result<Expr> {
         let mut expr = self.parse_or()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            match self.tokens[self.pos] {
-                Token::QuestionQuestion => {
-                    self.enter_nested("Coalesce chain is too deep")?;
-                    nested += 1;
-                    self.pos += 1;
-                    let right = self.parse_or()?;
-                    expr = Expr::Coalesce(Box::new(expr), Box::new(right));
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                match self.tokens[self.pos] {
+                    Token::QuestionQuestion => {
+                        self.enter_nested("Coalesce chain is too deep")?;
+                        nested += 1;
+                        self.pos += 1;
+                        let right = self.parse_or()?;
+                        expr = Expr::Coalesce(Box::new(expr), Box::new(right));
+                    }
+                    _ => break,
                 }
-                _ => break,
             }
-        }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `expr || expr`
     fn parse_or(&mut self) -> Result<Expr> {
         let mut expr = self.parse_and()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            match self.tokens[self.pos] {
-                Token::Or => {
-                    self.enter_nested("Logical OR chain is too deep")?;
-                    nested += 1;
-                    self.pos += 1;
-                    let right = self.parse_and()?;
-                    expr = Expr::Or(Box::new(expr), Box::new(right));
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                match self.tokens[self.pos] {
+                    Token::Or => {
+                        self.enter_nested("Logical OR chain is too deep")?;
+                        nested += 1;
+                        self.pos += 1;
+                        let right = self.parse_and()?;
+                        expr = Expr::Or(Box::new(expr), Box::new(right));
+                    }
+                    _ => break,
                 }
-                _ => break,
             }
-        }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// `expr && expr`
     fn parse_and(&mut self) -> Result<Expr> {
         let mut expr = self.parse_cmp()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            match self.tokens[self.pos] {
-                Token::And => {
-                    self.enter_nested("Logical AND chain is too deep")?;
-                    nested += 1;
-                    self.pos += 1;
-                    let right = self.parse_cmp()?;
-                    expr = Expr::And(Box::new(expr), Box::new(right));
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                match self.tokens[self.pos] {
+                    Token::And => {
+                        self.enter_nested("Logical AND chain is too deep")?;
+                        nested += 1;
+                        self.pos += 1;
+                        let right = self.parse_cmp()?;
+                        expr = Expr::And(Box::new(expr), Box::new(right));
+                    }
+                    _ => break,
                 }
-                _ => break,
             }
-        }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `expr == expr`
@@ -248,25 +257,28 @@ impl<'a> Parser<'a> {
     fn parse_cmp(&mut self) -> Result<Expr> {
         let mut expr = self.parse_add_sub()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            let op = match self.tokens[self.pos] {
-                Token::Eq => BinOp::Eq,
-                Token::Ne => BinOp::Ne,
-                Token::Gt => BinOp::Gt,
-                Token::Lt => BinOp::Lt,
-                Token::Ge => BinOp::Ge,
-                Token::Le => BinOp::Le,
-                Token::In => BinOp::In,
-                _ => break,
-            };
-            self.enter_nested("Comparison chain is too deep")?;
-            nested += 1;
-            self.pos += 1;
-            let right = self.parse_add_sub()?;
-            expr = Expr::Bin(Box::new(expr), op, Box::new(right));
-        }
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                let op = match self.tokens[self.pos] {
+                    Token::Eq => BinOp::Eq,
+                    Token::Ne => BinOp::Ne,
+                    Token::Gt => BinOp::Gt,
+                    Token::Lt => BinOp::Lt,
+                    Token::Ge => BinOp::Ge,
+                    Token::Le => BinOp::Le,
+                    Token::In => BinOp::In,
+                    _ => break,
+                };
+                self.enter_nested("Comparison chain is too deep")?;
+                nested += 1;
+                self.pos += 1;
+                let right = self.parse_add_sub()?;
+                expr = Expr::Bin(Box::new(expr), op, Box::new(right));
+            }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `expr + expr`
@@ -274,20 +286,23 @@ impl<'a> Parser<'a> {
     fn parse_add_sub(&mut self) -> Result<Expr> {
         let mut expr = self.parse_mul_div()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            let op = match self.tokens[self.pos] {
-                Token::Add => BinOp::Add,
-                Token::Sub => BinOp::Sub,
-                _ => break,
-            };
-            self.enter_nested("Add/sub chain is too deep")?;
-            nested += 1;
-            self.pos += 1;
-            let right = self.parse_mul_div()?;
-            expr = Expr::Bin(Box::new(expr), op, Box::new(right));
-        }
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                let op = match self.tokens[self.pos] {
+                    Token::Add => BinOp::Add,
+                    Token::Sub => BinOp::Sub,
+                    _ => break,
+                };
+                self.enter_nested("Add/sub chain is too deep")?;
+                nested += 1;
+                self.pos += 1;
+                let right = self.parse_mul_div()?;
+                expr = Expr::Bin(Box::new(expr), op, Box::new(right));
+            }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `expr * expr`
@@ -295,21 +310,24 @@ impl<'a> Parser<'a> {
     fn parse_mul_div(&mut self) -> Result<Expr> {
         let mut expr = self.parse_unary()?;
         let mut nested = 0usize;
-        while !self.eof() {
-            let op = match self.tokens[self.pos] {
-                Token::Mul => BinOp::Mul,
-                Token::Div => BinOp::Div,
-                Token::Mod => BinOp::Mod,
-                _ => break,
-            };
-            self.enter_nested("Mul/div chain is too deep")?;
-            nested += 1;
-            self.pos += 1;
-            let right = self.parse_unary()?;
-            expr = Expr::Bin(Box::new(expr), op, Box::new(right));
-        }
+        let result = (|| -> Result<Expr> {
+            while !self.eof() {
+                let op = match self.tokens[self.pos] {
+                    Token::Mul => BinOp::Mul,
+                    Token::Div => BinOp::Div,
+                    Token::Mod => BinOp::Mod,
+                    _ => break,
+                };
+                self.enter_nested("Mul/div chain is too deep")?;
+                nested += 1;
+                self.pos += 1;
+                let right = self.parse_unary()?;
+                expr = Expr::Bin(Box::new(expr), op, Box::new(right));
+            }
+            Ok(expr)
+        })();
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `!expr`
@@ -348,35 +366,39 @@ impl<'a> Parser<'a> {
         let mut expr = self.parse_primary()?;
         let mut nested = 0usize;
 
-        // 处理点访问
-        while !self.eof() && self.tokens[self.pos] == Token::Dot {
-            self.pos += 1;
-            self.ensure_not_eof("Expecting field after '.'")?;
+        // 在结果作用域内构建访问链,末尾无条件归还深度(含出错路径)。
+        let result = (|| -> Result<Expr> {
+            // 处理点访问
+            while !self.eof() && self.tokens[self.pos] == Token::Dot {
+                self.pos += 1;
+                self.ensure_not_eof("Expecting field after '.'")?;
 
-            let field = self.parse_field_accessor()?;
+                let field = self.parse_field_accessor()?;
 
-            match expr {
-                Expr::At(mut paths) => {
-                    // `@a` 后接的 `.b` 直接并入路径向量,eval 时按迭代展开,
-                    // 不加深 AST;仍需限制段数以防内存被无界撑大。
-                    if paths.len() >= MAX_AT_PATH_SEGMENTS {
-                        return Err(Error::Parse(self.err("Context access path is too deep")));
+                match expr {
+                    Expr::At(mut paths) => {
+                        // `@a` 后接的 `.b` 直接并入路径向量,eval 时按迭代展开,
+                        // 不加深 AST;仍需限制段数以防内存被无界撑大。
+                        if paths.len() >= MAX_AT_PATH_SEGMENTS {
+                            return Err(Error::Parse(self.err("Context access path is too deep")));
+                        }
+                        paths.push(Box::new(field));
+                        expr = Expr::At(paths);
                     }
-                    paths.push(Box::new(field));
-                    expr = Expr::At(paths);
-                }
-                _ => {
-                    // 每个 Access 节点都会加深 AST,eval/fold/Drop 都按此深度递归,
-                    // 必须纳入深度守卫以防栈溢出。
-                    self.enter_nested("Access chain is too deep")?;
-                    nested += 1;
-                    expr = Expr::Access(Box::new(expr), Box::new(field));
+                    _ => {
+                        // 每个 Access 节点都会加深 AST,eval/fold/Drop 都按此深度递归,
+                        // 必须纳入深度守卫以防栈溢出。
+                        self.enter_nested("Access chain is too deep")?;
+                        nested += 1;
+                        expr = Expr::Access(Box::new(expr), Box::new(field));
+                    }
                 }
             }
-        }
+            Ok(expr)
+        })();
 
         self.leave_nested_n(nested);
-        Ok(expr)
+        result
     }
 
     /// - `nil`

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 const MAX_PARSE_DEPTH: usize = 128;
-const MAX_BINARY_CHAIN_LEN: usize = 256;
 const MAX_AT_PATH_SEGMENTS: usize = 256;
 static NIL_TOKEN: Token = Token::Nil;
 
@@ -186,14 +185,12 @@ impl<'a> Parser<'a> {
     /// `expr ?? expr` (left-associative nullish coalescing)
     fn parse_coalesce(&mut self) -> Result<Expr> {
         let mut expr = self.parse_or()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             match self.tokens[self.pos] {
                 Token::QuestionQuestion => {
-                    chain_len += 1;
-                    if chain_len > MAX_BINARY_CHAIN_LEN {
-                        return Err(Error::Parse(self.err("Coalesce chain is too long")));
-                    }
+                    self.enter_nested("Coalesce chain is too deep")?;
+                    nested += 1;
                     self.pos += 1;
                     let right = self.parse_or()?;
                     expr = Expr::Coalesce(Box::new(expr), Box::new(right));
@@ -201,20 +198,19 @@ impl<'a> Parser<'a> {
                 _ => break,
             }
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
     /// - `expr || expr`
     fn parse_or(&mut self) -> Result<Expr> {
         let mut expr = self.parse_and()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             match self.tokens[self.pos] {
                 Token::Or => {
-                    chain_len += 1;
-                    if chain_len > MAX_BINARY_CHAIN_LEN {
-                        return Err(Error::Parse(self.err("Logical OR chain is too long")));
-                    }
+                    self.enter_nested("Logical OR chain is too deep")?;
+                    nested += 1;
                     self.pos += 1;
                     let right = self.parse_and()?;
                     expr = Expr::Or(Box::new(expr), Box::new(right));
@@ -222,20 +218,19 @@ impl<'a> Parser<'a> {
                 _ => break,
             }
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
     /// `expr && expr`
     fn parse_and(&mut self) -> Result<Expr> {
         let mut expr = self.parse_cmp()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             match self.tokens[self.pos] {
                 Token::And => {
-                    chain_len += 1;
-                    if chain_len > MAX_BINARY_CHAIN_LEN {
-                        return Err(Error::Parse(self.err("Logical AND chain is too long")));
-                    }
+                    self.enter_nested("Logical AND chain is too deep")?;
+                    nested += 1;
                     self.pos += 1;
                     let right = self.parse_cmp()?;
                     expr = Expr::And(Box::new(expr), Box::new(right));
@@ -243,6 +238,7 @@ impl<'a> Parser<'a> {
                 _ => break,
             }
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
@@ -251,7 +247,7 @@ impl<'a> Parser<'a> {
     ///   ...
     fn parse_cmp(&mut self) -> Result<Expr> {
         let mut expr = self.parse_add_sub()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             let op = match self.tokens[self.pos] {
                 Token::Eq => BinOp::Eq,
@@ -263,14 +259,13 @@ impl<'a> Parser<'a> {
                 Token::In => BinOp::In,
                 _ => break,
             };
-            chain_len += 1;
-            if chain_len > MAX_BINARY_CHAIN_LEN {
-                return Err(Error::Parse(self.err("Comparison chain is too long")));
-            }
+            self.enter_nested("Comparison chain is too deep")?;
+            nested += 1;
             self.pos += 1;
             let right = self.parse_add_sub()?;
             expr = Expr::Bin(Box::new(expr), op, Box::new(right));
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
@@ -278,21 +273,20 @@ impl<'a> Parser<'a> {
     /// - `expr - expr`
     fn parse_add_sub(&mut self) -> Result<Expr> {
         let mut expr = self.parse_mul_div()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             let op = match self.tokens[self.pos] {
                 Token::Add => BinOp::Add,
                 Token::Sub => BinOp::Sub,
                 _ => break,
             };
-            chain_len += 1;
-            if chain_len > MAX_BINARY_CHAIN_LEN {
-                return Err(Error::Parse(self.err("Add/sub chain is too long")));
-            }
+            self.enter_nested("Add/sub chain is too deep")?;
+            nested += 1;
             self.pos += 1;
             let right = self.parse_mul_div()?;
             expr = Expr::Bin(Box::new(expr), op, Box::new(right));
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
@@ -300,7 +294,7 @@ impl<'a> Parser<'a> {
     /// - `expr / expr`
     fn parse_mul_div(&mut self) -> Result<Expr> {
         let mut expr = self.parse_unary()?;
-        let mut chain_len = 0usize;
+        let mut nested = 0usize;
         while !self.eof() {
             let op = match self.tokens[self.pos] {
                 Token::Mul => BinOp::Mul,
@@ -308,14 +302,13 @@ impl<'a> Parser<'a> {
                 Token::Mod => BinOp::Mod,
                 _ => break,
             };
-            chain_len += 1;
-            if chain_len > MAX_BINARY_CHAIN_LEN {
-                return Err(Error::Parse(self.err("Mul/div chain is too long")));
-            }
+            self.enter_nested("Mul/div chain is too deep")?;
+            nested += 1;
             self.pos += 1;
             let right = self.parse_unary()?;
             expr = Expr::Bin(Box::new(expr), op, Box::new(right));
         }
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
@@ -353,6 +346,7 @@ impl<'a> Parser<'a> {
     /// - `primary.field.field`
     fn parse_postfix(&mut self) -> Result<Expr> {
         let mut expr = self.parse_primary()?;
+        let mut nested = 0usize;
 
         // 处理点访问
         while !self.eof() && self.tokens[self.pos] == Token::Dot {
@@ -363,15 +357,25 @@ impl<'a> Parser<'a> {
 
             match expr {
                 Expr::At(mut paths) => {
+                    // `@a` 后接的 `.b` 直接并入路径向量,eval 时按迭代展开,
+                    // 不加深 AST;仍需限制段数以防内存被无界撑大。
+                    if paths.len() >= MAX_AT_PATH_SEGMENTS {
+                        return Err(Error::Parse(self.err("Context access path is too deep")));
+                    }
                     paths.push(Box::new(field));
                     expr = Expr::At(paths);
                 }
                 _ => {
+                    // 每个 Access 节点都会加深 AST,eval/fold/Drop 都按此深度递归,
+                    // 必须纳入深度守卫以防栈溢出。
+                    self.enter_nested("Access chain is too deep")?;
+                    nested += 1;
                     expr = Expr::Access(Box::new(expr), Box::new(field));
                 }
             }
         }
 
+        self.leave_nested_n(nested);
         Ok(expr)
     }
 
@@ -607,5 +611,14 @@ impl<'a> Parser<'a> {
 
     fn leave_nested(&mut self) {
         self.depth = self.depth.saturating_sub(1);
+    }
+
+    /// Release `n` nesting levels at once. Used by the binary-operator and
+    /// postfix-access loops, which build a left-leaning spine iteratively:
+    /// each iteration reserves one level so `depth` tracks the real AST depth
+    /// (i.e. the worst-case eval recursion), then the whole chain is released
+    /// on return so sibling sub-expressions take the max rather than the sum.
+    fn leave_nested_n(&mut self, n: usize) {
+        self.depth = self.depth.saturating_sub(n);
     }
 }

--- a/src/ast_test.rs
+++ b/src/ast_test.rs
@@ -442,6 +442,40 @@ mod test {
     }
 
     #[test]
+    fn deeply_nested_postfix_access_is_rejected() {
+        // `nil.a.a.a...` builds a left-leaning Access spine; without a depth
+        // bound this overflowed the stack in fold_constants/eval/Drop.
+        let mut expr = "nil".to_string();
+        for _ in 0..5000 {
+            expr.push_str(".a");
+        }
+        let result = Expr::try_from(expr.as_str());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too deep"));
+    }
+
+    #[test]
+    fn deeply_multiplied_paren_chain_is_rejected() {
+        // Parens (bounded) times binary chains (bounded) previously composed
+        // into an unbounded AST spine that overflowed the stack.
+        let mut expr = "1".to_string();
+        for _ in 0..200 {
+            expr = format!("({expr})");
+            expr.push_str(&"*1".repeat(200));
+        }
+        let result = Expr::try_from(expr.as_str());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too deep"));
+    }
+
+    #[test]
+    fn long_binary_chain_is_rejected() {
+        // A single very long operator chain builds a deep left-leaning tree.
+        let expr = format!("1{}", "+1".repeat(5000));
+        assert!(Expr::try_from(expr.as_str()).is_err());
+    }
+
+    #[test]
     fn deeply_nested_ternary_is_rejected() {
         // Build: true ? true : true ? true : ... (chain of 300 ternaries)
         let mut expr = "true".to_string();

--- a/src/ast_test.rs
+++ b/src/ast_test.rs
@@ -476,6 +476,21 @@ mod test {
     }
 
     #[test]
+    fn nesting_at_exactly_max_depth_parses() {
+        use crate::ast::MAX_PARSE_DEPTH;
+        // `MAX_PARSE_DEPTH - 1` nested parens drive the depth guard to exactly
+        // MAX_PARSE_DEPTH and must still parse; one more level is rejected.
+        let boundary = MAX_PARSE_DEPTH - 1;
+        let ok = format!("{}1{}", "(".repeat(boundary), ")".repeat(boundary));
+        assert!(Expr::try_from(ok.as_str()).is_ok());
+
+        let too_deep = format!("{}1{}", "(".repeat(MAX_PARSE_DEPTH), ")".repeat(MAX_PARSE_DEPTH));
+        let result = Expr::try_from(too_deep.as_str());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too deep"));
+    }
+
+    #[test]
     fn deeply_nested_ternary_is_rejected() {
         // Build: true ? true : true ? true : ... (chain of 300 ternaries)
         let mut expr = "true".to_string();

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -34,8 +34,6 @@ const MAX_PARSE_CACHE_ENTRIES: usize = 4096;
 const MAX_CACHED_EXPR_LEN: usize = 4096;
 #[cfg(feature = "std")]
 const PARSE_CACHE_SHARDS: usize = 16;
-#[cfg(feature = "std")]
-const MAX_LITERAL_CONTAINER_CACHE_ENTRIES: usize = 1024;
 
 /// Grammar:
 /// exp      ::= ternary
@@ -115,8 +113,14 @@ struct ParseCacheShard {
 }
 
 #[cfg(feature = "std")]
+struct CacheEntry {
+    expr: Arc<Expr>,
+    last_used: AtomicU64,
+}
+
+#[cfg(feature = "std")]
 struct ParseCacheState {
-    entries: HashMap<String, (Arc<Expr>, u64)>,
+    entries: HashMap<String, CacheEntry>,
 }
 
 #[cfg(feature = "std")]
@@ -130,10 +134,15 @@ impl ParseCacheState {
         }
     }
 
-    fn get(&mut self, expression: &str) -> Option<Arc<Expr>> {
-        let entry = self.entries.get_mut(expression)?;
-        entry.1 = CACHE_CLOCK.fetch_add(1, Ordering::Relaxed);
-        Some(entry.0.clone())
+    /// Look up under a shared (read) lock. The LRU timestamp lives in an atomic
+    /// so a cache hit — the hot path for repeated ACL checks — only needs a
+    /// shared lock and never serializes readers within a shard.
+    fn get(&self, expression: &str) -> Option<Arc<Expr>> {
+        let entry = self.entries.get(expression)?;
+        entry
+            .last_used
+            .store(CACHE_CLOCK.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
+        Some(entry.expr.clone())
     }
 
     fn insert(&mut self, expression: String, expr: Arc<Expr>) {
@@ -146,14 +155,20 @@ impl ParseCacheState {
         }
 
         let ts = CACHE_CLOCK.fetch_add(1, Ordering::Relaxed);
-        self.entries.insert(expression, (expr, ts));
+        self.entries.insert(
+            expression,
+            CacheEntry {
+                expr,
+                last_used: AtomicU64::new(ts),
+            },
+        );
     }
 
     fn evict_oldest(&mut self) {
         if let Some(oldest_key) = self
             .entries
             .iter()
-            .min_by_key(|(_, (_, ts))| *ts)
+            .min_by_key(|(_, entry)| entry.last_used.load(Ordering::Relaxed))
             .map(|(k, _)| k.clone())
         {
             self.entries.remove(&oldest_key);
@@ -170,10 +185,6 @@ static PARSE_CACHE: Lazy<Box<[ParseCacheShard]>> = Lazy::new(|| {
         .collect::<Vec<_>>()
         .into_boxed_slice()
 });
-
-#[cfg(feature = "std")]
-static LITERAL_CONTAINER_CACHE: Lazy<RwLock<HashMap<usize, Val>>> =
-    Lazy::new(|| RwLock::new(HashMap::new()));
 
 #[cfg(feature = "std")]
 #[inline]
@@ -193,30 +204,6 @@ fn parse_cache_shard_idx(expression: &str) -> usize {
 #[inline]
 fn parse_cache_shard(expression: &str) -> &'static ParseCacheShard {
     &PARSE_CACHE[parse_cache_shard_idx(expression)]
-}
-
-#[cfg(feature = "std")]
-#[inline]
-fn literal_container_cache_key(expr: &Expr) -> usize {
-    expr as *const Expr as usize
-}
-
-#[cfg(feature = "std")]
-fn literal_container_cache_get(expr: &Expr) -> Option<Val> {
-    LITERAL_CONTAINER_CACHE
-        .read()
-        .unwrap()
-        .get(&literal_container_cache_key(expr))
-        .cloned()
-}
-
-#[cfg(feature = "std")]
-fn literal_container_cache_insert(expr: &Expr, value: &Val) {
-    let mut cache = LITERAL_CONTAINER_CACHE.write().unwrap();
-    if cache.len() >= MAX_LITERAL_CONTAINER_CACHE_ENTRIES {
-        cache.clear();
-    }
-    cache.insert(literal_container_cache_key(expr), value.clone());
 }
 
 impl Expr {
@@ -303,13 +290,6 @@ impl Expr {
                 }
             }
             Expr::List(exprs) => {
-                #[cfg(feature = "std")]
-                if exprs.iter().all(|expr| matches!(&**expr, Expr::Val(_))) {
-                    if let Some(cached) = literal_container_cache_get(self) {
-                        return Ok(cached);
-                    }
-                }
-
                 let mut values = Vec::with_capacity(exprs.len());
                 for expr in exprs {
                     values.push(match &**expr {
@@ -317,24 +297,9 @@ impl Expr {
                         _ => expr.eval(ctx)?,
                     });
                 }
-                let result = Val::List(Arc::new(values));
-                #[cfg(feature = "std")]
-                if exprs.iter().all(|expr| matches!(&**expr, Expr::Val(_))) {
-                    literal_container_cache_insert(self, &result);
-                }
-                Ok(result)
+                Ok(Val::List(Arc::new(values)))
             }
             Expr::Map(pairs) => {
-                #[cfg(feature = "std")]
-                if pairs
-                    .iter()
-                    .all(|(key, value)| matches!(&**key, Expr::Val(_)) && matches!(&**value, Expr::Val(_)))
-                {
-                    if let Some(cached) = literal_container_cache_get(self) {
-                        return Ok(cached);
-                    }
-                }
-
                 let mut map = hashbrown::HashMap::with_capacity(pairs.len());
                 for (key_expr, value_expr) in pairs {
                     let key_tmp;
@@ -359,15 +324,7 @@ impl Expr {
 
                     map.insert(key_str, value_val);
                 }
-                let result = Val::Map(Arc::new(map));
-                #[cfg(feature = "std")]
-                if pairs
-                    .iter()
-                    .all(|(key, value)| matches!(&**key, Expr::Val(_)) && matches!(&**value, Expr::Val(_)))
-                {
-                    literal_container_cache_insert(self, &result);
-                }
-                Ok(result)
+                Ok(Val::Map(Arc::new(map)))
             }
             Expr::Paren(expr) => expr.eval(ctx),
             Expr::Val(val) => Ok(val.clone()), // Clone necessary as eval returns owned Val
@@ -474,7 +431,7 @@ impl Expr {
     pub fn parse_cached_arc(expression: &str) -> Result<Arc<Expr>> {
         if expression.len() <= MAX_CACHED_EXPR_LEN {
             let shard = parse_cache_shard(expression);
-            if let Some(cached) = shard.state.write().unwrap().get(expression) {
+            if let Some(cached) = shard.state.read().unwrap().get(expression) {
                 return Ok(cached);
             }
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -139,9 +139,11 @@ impl ParseCacheState {
     /// shared lock and never serializes readers within a shard.
     fn get(&self, expression: &str) -> Option<Arc<Expr>> {
         let entry = self.entries.get(expression)?;
+        // fetch_max keeps last_used monotonic: two readers racing under the
+        // shared lock cannot let an earlier ticket overwrite a later one's.
         entry
             .last_used
-            .store(CACHE_CLOCK.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
+            .fetch_max(CACHE_CLOCK.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
         Some(entry.expr.clone())
     }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -41,71 +41,130 @@ pub enum Token {
     Id(Arc<str>),     // identifier
 }
 
-/// [chars] and [idx] can be used for syntax error reporting.
-pub struct Tokenizer {
-    chars: Vec<char>,
+/// Byte-oriented tokenizer. `input`/`idx` index UTF-8 bytes directly, avoiding a
+/// full `Vec<char>` copy of the source; identifiers and string literals without
+/// escapes are sliced straight out of `input` with no intermediate allocation.
+/// `idx` is always kept on a UTF-8 char boundary.
+pub struct Tokenizer<'a> {
+    input: &'a str,
+    bytes: &'a [u8],
     idx: usize,
     len: usize,
     pub tokens: Vec<Token>,
 }
 
-impl Tokenizer {
+impl<'a> Tokenizer<'a> {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(s: &str) -> Result<Vec<Token>> {
-        let chars: Vec<char> = s.chars().collect();
-        let len = chars.len();
         let mut t = Tokenizer {
-            chars,
+            input: s,
+            bytes: s.as_bytes(),
             idx: 0,
-            len,
+            len: s.len(),
             tokens: Vec::with_capacity(s.len() / 4), // Preallocate a reasonable size
         };
         t.parse()?;
         Ok(t.tokens)
     }
 
+    #[inline]
     fn eof(&self) -> bool {
         self.idx >= self.len
     }
 
-    fn peek(&self, offset: usize) -> Option<char> {
-        self.chars.get(self.idx + offset).copied()
+    /// Current byte. Only call when `!self.eof()`.
+    #[inline]
+    fn cur_byte(&self) -> u8 {
+        self.bytes[self.idx]
+    }
+
+    #[inline]
+    fn byte_at(&self, i: usize) -> Option<u8> {
+        self.bytes.get(i).copied()
+    }
+
+    /// Decode the char starting at `byte_idx` (must be a char boundary).
+    #[inline]
+    fn char_at(&self, byte_idx: usize) -> Option<char> {
+        self.input.get(byte_idx..).and_then(|s| s.chars().next())
+    }
+
+    #[inline]
+    fn cur_char(&self) -> Option<char> {
+        self.char_at(self.idx)
+    }
+
+    /// The char immediately after the current one. All call sites have an ASCII
+    /// (single-byte) current char, so `idx + 1` is a valid boundary there.
+    #[inline]
+    fn peek1(&self) -> Option<char> {
+        self.char_at(self.idx + 1)
     }
 
     fn err<T: AsRef<str>>(&self, msg: T) -> String {
         // Compute line:col from idx by scanning from start
         let mut line = 1usize;
         let mut col = 1usize;
-        for i in 0..self.idx.min(self.len) {
-            if self.chars[i] == '\n' {
+        let scanned = self.idx.min(self.len);
+        for c in self.input[..scanned].chars() {
+            if c == '\n' {
                 line += 1;
                 col = 1;
             } else {
                 col += 1;
             }
         }
-        // Collect near 10(max) chars around the error position
-        let r_idx = if self.idx + 5 < self.len {
-            self.idx + 5
+        // Collect near ~10 chars around the error position (char-boundary safe)
+        let l_idx = self.char_window_start(5);
+        let r_idx = self.char_window_end(5);
+        let near = &self.input[l_idx..r_idx];
+        let c = self.cur_char();
+        let ctx = if let Some(c) = c {
+            format!("'{}' at {}:{}, near '{}'", c, line, col, near)
         } else {
-            self.len
-        };
-        let l_idx = self.idx.saturating_sub(5);
-        let r_idx = if r_idx > self.len { self.len } else { r_idx };
-        let chars = &self.chars[l_idx..r_idx];
-        let chars: String = chars.iter().collect();
-        let c = self.chars.get(self.idx);
-        let ctx = if let Some(&c) = c {
-            format!("'{}' at {}:{}, near '{}'", c, line, col, chars)
-        } else {
-            format!("at end ({}:{}), near '{}'", line, col, chars)
+            format!("at end ({}:{}), near '{}'", line, col, near)
         };
         format!("Syntax error:\n{} ({})", msg.as_ref(), ctx)
     }
 
+    /// Byte offset ~`n` chars before `idx`, clamped to a char boundary.
+    fn char_window_start(&self, n: usize) -> usize {
+        let mut idx = self.idx.min(self.len);
+        for _ in 0..n {
+            if idx == 0 {
+                break;
+            }
+            idx -= 1;
+            while idx > 0 && !self.input.is_char_boundary(idx) {
+                idx -= 1;
+            }
+        }
+        idx
+    }
+
+    /// Byte offset ~`n` chars after `idx`, clamped to a char boundary.
+    fn char_window_end(&self, n: usize) -> usize {
+        let mut idx = self.idx.min(self.len);
+        for _ in 0..n {
+            if idx >= self.len {
+                break;
+            }
+            idx += 1;
+            while idx < self.len && !self.input.is_char_boundary(idx) {
+                idx += 1;
+            }
+        }
+        idx
+    }
+
     fn skip_whitespace(&mut self) {
-        while self.idx < self.len && self.chars[self.idx].is_whitespace() {
-            self.idx += 1;
+        while !self.eof() {
+            let c = self.cur_char().unwrap();
+            if c.is_whitespace() {
+                self.idx += c.len_utf8();
+            } else {
+                break;
+            }
         }
     }
 
@@ -127,11 +186,11 @@ impl Tokenizer {
 
     fn parse_str(&mut self) -> Result<()> {
         let mut s = String::new();
-        let quote = self.chars[self.idx];
+        let quote = self.cur_char().unwrap(); // ' or " (ASCII)
         self.idx += 1;
 
         while !self.eof() {
-            let c = self.chars[self.idx];
+            let c = self.cur_char().unwrap();
             match c {
                 '\\' => {
                     self.idx += 1;
@@ -139,7 +198,8 @@ impl Tokenizer {
                         return Err(Error::Tokenize(self.err("Invalid escape sequence")));
                     }
 
-                    let escaped = match self.chars[self.idx] {
+                    let next = self.cur_char().unwrap();
+                    let escaped = match next {
                         '\\' => '\\',
                         '"' => '"',
                         '\'' => '\'',
@@ -152,8 +212,15 @@ impl Tokenizer {
                             if self.idx + 4 > self.len {
                                 return Err(Error::Tokenize(self.err("Invalid \\uXXXX escape, need 4 hex digits")));
                             }
-                            let hex: String = self.chars[self.idx..self.idx + 4].iter().collect();
-                            let code = u32::from_str_radix(&hex, 16)
+                            // Validate on raw bytes first so the &str slice below is
+                            // guaranteed to land on a char boundary.
+                            let hb = &self.bytes[self.idx..self.idx + 4];
+                            if !hb.iter().all(|b| b.is_ascii_hexdigit()) {
+                                let shown = core::str::from_utf8(hb).unwrap_or("????");
+                                return Err(Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{shown}"))));
+                            }
+                            let hex = &self.input[self.idx..self.idx + 4];
+                            let code = u32::from_str_radix(hex, 16)
                                 .map_err(|_| Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{hex}"))))?;
                             let ch = char::from_u32(code).ok_or_else(|| {
                                 Error::Tokenize(self.err(format!("Invalid unicode codepoint: \\u{hex}")))
@@ -169,7 +236,7 @@ impl Tokenizer {
                         }
                     };
                     s.push(escaped);
-                    self.idx += 1;
+                    self.idx += 1; // escape letter is ASCII
                 }
                 c if c == quote => {
                     self.idx += 1;
@@ -178,7 +245,7 @@ impl Tokenizer {
                 }
                 _ => {
                     s.push(c);
-                    self.idx += 1;
+                    self.idx += c.len_utf8();
                 }
             }
         }
@@ -215,18 +282,16 @@ impl Tokenizer {
         let start_idx = self.idx;
 
         // Handle optional sign prefix
-        if !self.eof() && (self.chars[self.idx] == '-' || self.chars[self.idx] == '+') {
+        if !self.eof() && matches!(self.cur_byte(), b'-' | b'+') {
             self.idx += 1;
         }
 
         // Check for hex (0x) or octal (0o) prefix
         if !self.eof()
-            && self.chars[self.idx] == '0'
-            && self.idx + 1 < self.len
-            && (self.chars[self.idx + 1] == 'x'
-                || self.chars[self.idx + 1] == 'X'
-                || self.chars[self.idx + 1] == 'o'
-                || self.chars[self.idx + 1] == 'O')
+            && self.cur_byte() == b'0'
+            && self
+                .byte_at(self.idx + 1)
+                .is_some_and(|b| matches!(b, b'x' | b'X' | b'o' | b'O'))
         {
             self.idx = start_idx;
             return self.parse_int();
@@ -236,27 +301,27 @@ impl Tokenizer {
         self.idx = start_idx;
         let mut dot_count = 0;
         while !self.eof() {
-            let c = self.chars[self.idx];
-            if c.is_ascii_digit() {
+            let b = self.cur_byte();
+            if b.is_ascii_digit() {
                 self.idx += 1;
-            } else if c == '.' {
+            } else if b == b'.' {
                 if dot_count > 0 {
                     return Err(Error::Tokenize(self.err("Invalid float, multiple '.'")));
                 }
                 self.idx += 1;
                 dot_count += 1;
-            } else if (c == '-' || c == '+') && self.idx == start_idx {
+            } else if matches!(b, b'-' | b'+') && self.idx == start_idx {
                 self.idx += 1;
             } else {
                 break;
             }
         }
 
-        if self.idx > start_idx && self.chars[self.idx - 1] == '.' {
+        if self.idx > start_idx && self.bytes[self.idx - 1] == b'.' {
             return Err(Error::Tokenize(self.err("Invalid float, ends with '.'")));
         }
 
-        let num_str: String = self.chars[start_idx..self.idx].iter().collect();
+        let num_str = &self.input[start_idx..self.idx];
 
         let num = if dot_count > 0 {
             match num_str.parse() {
@@ -274,7 +339,7 @@ impl Tokenizer {
     }
 
     fn parse_id(&mut self) -> Result<()> {
-        if self.eof() || !Self::is_id_start(self.chars[self.idx]) {
+        if self.eof() || !self.cur_char().is_some_and(Self::is_id_start) {
             return Err(Error::Tokenize(self.err("Invalid identifier start")));
         }
 
@@ -285,20 +350,27 @@ impl Tokenizer {
     }
 
     fn scan_id_end(&self, start_idx: usize) -> usize {
-        let mut end = start_idx + 1;
-        while end < self.len && Self::is_id_continue(self.chars[end]) {
-            end += 1;
+        // Caller guarantees the char at start_idx is an id-start.
+        let first = self.char_at(start_idx).unwrap();
+        let mut end = start_idx + first.len_utf8();
+        while end < self.len {
+            let c = self.char_at(end).unwrap();
+            if Self::is_id_continue(c) {
+                end += c.len_utf8();
+            } else {
+                break;
+            }
         }
         end
     }
 
     fn push_id_token(&mut self, start_idx: usize, end_idx: usize) {
-        let id: String = self.chars[start_idx..end_idx].iter().collect();
+        let id = &self.input[start_idx..end_idx];
         self.tokens.push(Token::Id(Arc::<str>::from(id)));
     }
 
     fn parse_ident_or_keyword(&mut self) -> Result<()> {
-        if self.eof() || !Self::is_id_start(self.chars[self.idx]) {
+        if self.eof() || !self.cur_char().is_some_and(Self::is_id_start) {
             return Err(Error::Tokenize(self.err("Invalid identifier start")));
         }
 
@@ -306,11 +378,11 @@ impl Tokenizer {
         let end_idx = self.scan_id_end(start_idx);
         self.idx = end_idx;
 
-        let token = match &self.chars[start_idx..end_idx] {
-            ['t', 'r', 'u', 'e'] => Token::Bool(true),
-            ['f', 'a', 'l', 's', 'e'] => Token::Bool(false),
-            ['n', 'i', 'l'] => Token::Nil,
-            ['i', 'n'] => Token::In,
+        let token = match &self.input[start_idx..end_idx] {
+            "true" => Token::Bool(true),
+            "false" => Token::Bool(false),
+            "nil" => Token::Nil,
+            "in" => Token::In,
             _ => {
                 self.push_id_token(start_idx, end_idx);
                 return Ok(());
@@ -323,11 +395,11 @@ impl Tokenizer {
     /// - `@a.(@b - 1)` -> [At, Id("a"), Dot, LParen, At, Id("b"), Sub, Int(1), RParen]
     /// - `@a` -> [At, Id("a")]
     fn parse_at_list(&mut self) -> Result<()> {
-        self.idx += 1;
+        self.idx += 1; // '@' is ASCII
         self.tokens.push(Token::At);
 
         while !self.eof() {
-            let c = self.chars[self.idx];
+            let c = self.cur_char().unwrap();
             if Self::is_id_start(c) {
                 self.parse_id()?;
                 continue;
@@ -336,11 +408,12 @@ impl Tokenizer {
                 self.parse_int()?;
                 continue;
             }
-            if matches!(c, '+' | '-') && self.tokens.last().is_some_and(|tok| tok == &Token::Dot) {
-                if self.peek(1).is_some_and(|next| next.is_ascii_digit()) {
-                    self.parse_int()?;
-                    continue;
-                }
+            if matches!(c, '+' | '-')
+                && self.tokens.last().is_some_and(|tok| tok == &Token::Dot)
+                && self.peek1().is_some_and(|next| next.is_ascii_digit())
+            {
+                self.parse_int()?;
+                continue;
             }
 
             if c == '.' {
@@ -356,28 +429,26 @@ impl Tokenizer {
     fn parse_int(&mut self) -> Result<()> {
         let start_idx = self.idx;
 
-        if !self.eof() && (self.chars[self.idx] == '-' || self.chars[self.idx] == '+') {
+        if !self.eof() && matches!(self.cur_byte(), b'-' | b'+') {
             self.idx += 1;
         }
 
         if !self.eof()
-            && self.chars[self.idx] == '0'
-            && self.idx + 1 < self.len
-            && (self.chars[self.idx + 1] == 'x'
-                || self.chars[self.idx + 1] == 'X'
-                || self.chars[self.idx + 1] == 'o'
-                || self.chars[self.idx + 1] == 'O')
+            && self.cur_byte() == b'0'
+            && self
+                .byte_at(self.idx + 1)
+                .is_some_and(|b| matches!(b, b'x' | b'X' | b'o' | b'O'))
         {
-            let is_hex = self.chars[self.idx + 1] == 'x' || self.chars[self.idx + 1] == 'X';
+            let is_hex = matches!(self.byte_at(self.idx + 1), Some(b'x') | Some(b'X'));
             let radix = if is_hex { 16 } else { 8 };
             self.idx += 2; // skip '0x' or '0o'
             let digits_start = self.idx;
             while !self.eof() {
-                let c = self.chars[self.idx];
+                let b = self.cur_byte();
                 let valid = if is_hex {
-                    c.is_ascii_hexdigit()
+                    b.is_ascii_hexdigit()
                 } else {
-                    matches!(c, '0'..='7')
+                    matches!(b, b'0'..=b'7')
                 };
                 if valid {
                     self.idx += 1;
@@ -389,11 +460,11 @@ impl Tokenizer {
                 let label = if is_hex { "hex" } else { "octal" };
                 return Err(Error::Tokenize(self.err(format!("Invalid {label} literal, no digits"))));
             }
-            let digits: String = self.chars[digits_start..self.idx].iter().collect();
-            let val = i64::from_str_radix(&digits, radix).map_err(|_| {
+            let digits = &self.input[digits_start..self.idx];
+            let val = i64::from_str_radix(digits, radix).map_err(|_| {
                 Error::Tokenize(self.err(format!("Invalid int: 0{}{}", if is_hex { "x" } else { "o" }, digits)))
             })?;
-            let val = if start_idx < self.chars.len() && self.chars[start_idx] == '-' {
+            let val = if self.byte_at(start_idx) == Some(b'-') {
                 val.checked_neg()
                     .ok_or_else(|| Error::Tokenize(self.err("Integer overflow")))?
             } else {
@@ -404,15 +475,15 @@ impl Tokenizer {
         }
 
         while !self.eof() {
-            let c = self.chars[self.idx];
-            if c.is_ascii_digit() {
+            let b = self.cur_byte();
+            if b.is_ascii_digit() {
                 self.idx += 1;
             } else {
                 break;
             }
         }
 
-        let num_str: String = self.chars[start_idx..self.idx].iter().collect();
+        let num_str = &self.input[start_idx..self.idx];
         let num = match num_str.parse() {
             Ok(i) => i,
             Err(_) => return Err(Error::Tokenize(format!("{}: {}", self.err("Invalid int"), num_str))),
@@ -422,7 +493,7 @@ impl Tokenizer {
     }
 
     fn parse_punctuations(&mut self) -> Result<()> {
-        let c = self.chars[self.idx];
+        let c = self.cur_char().unwrap();
         match c {
             '(' => {
                 self.idx += 1;
@@ -478,7 +549,7 @@ impl Tokenizer {
                 Ok(())
             }
             '&' => {
-                if self.peek(1) == Some('&') {
+                if self.peek1() == Some('&') {
                     self.idx += 2;
                     self.tokens.push(Token::And);
                     Ok(())
@@ -487,7 +558,7 @@ impl Tokenizer {
                 }
             }
             '|' => {
-                if self.peek(1) == Some('|') {
+                if self.peek1() == Some('|') {
                     self.idx += 2;
                     self.tokens.push(Token::Or);
                     Ok(())
@@ -496,7 +567,7 @@ impl Tokenizer {
                 }
             }
             '+' => {
-                if self.sign_starts_number() && self.peek(1).is_some_and(|next| next.is_ascii_digit()) {
+                if self.sign_starts_number() && self.peek1().is_some_and(|next| next.is_ascii_digit()) {
                     return self.parse_num();
                 }
                 self.idx += 1;
@@ -504,7 +575,7 @@ impl Tokenizer {
                 Ok(())
             }
             '-' => {
-                if self.sign_starts_number() && self.peek(1).is_some_and(|next| next.is_ascii_digit()) {
+                if self.sign_starts_number() && self.peek1().is_some_and(|next| next.is_ascii_digit()) {
                     return self.parse_num();
                 }
                 self.idx += 1;
@@ -517,34 +588,36 @@ impl Tokenizer {
                 Ok(())
             }
             '/' => {
-                if self.peek(1) == Some('*') {
+                if self.peek1() == Some('*') {
                     // Multi-line comment with nesting support
                     self.idx += 2;
                     let mut depth = 1usize;
                     while !self.eof() && depth > 0 {
-                        if self.chars[self.idx] == '/' && self.peek(1) == Some('*') {
+                        if self.cur_byte() == b'/' && self.peek1() == Some('*') {
                             depth += 1;
                             self.idx += 2;
-                        } else if self.chars[self.idx] == '*' && self.peek(1) == Some('/') {
+                        } else if self.cur_byte() == b'*' && self.peek1() == Some('/') {
                             depth -= 1;
                             self.idx += 2;
                         } else {
-                            self.idx += 1;
+                            // Comment body may hold multibyte UTF-8; advance a full char.
+                            let ch = self.cur_char().unwrap();
+                            self.idx += ch.len_utf8();
                         }
                     }
                     if depth > 0 {
                         return Err(Error::Tokenize(self.err("Unterminated block comment")));
                     }
-                } else if self.peek(1) == Some('/') {
+                } else if self.peek1() == Some('/') {
                     self.idx += 2;
                     // Skip single-line comment
                     while !self.eof() {
-                        let c = self.chars[self.idx];
-                        if c == '\n' {
+                        if self.cur_byte() == b'\n' {
                             self.idx += 1;
                             break;
                         }
-                        self.idx += 1;
+                        let ch = self.cur_char().unwrap();
+                        self.idx += ch.len_utf8();
                     }
                 } else {
                     self.idx += 1;
@@ -559,7 +632,7 @@ impl Tokenizer {
             }
             '@' => self.parse_at_list(),
             '=' => {
-                if self.peek(1) == Some('=') {
+                if self.peek1() == Some('=') {
                     self.idx += 2;
                     self.tokens.push(Token::Eq);
                     Ok(())
@@ -568,7 +641,7 @@ impl Tokenizer {
                 }
             }
             '!' => {
-                if self.peek(1) == Some('=') {
+                if self.peek1() == Some('=') {
                     self.idx += 2;
                     self.tokens.push(Token::Ne);
                     Ok(())
@@ -579,7 +652,7 @@ impl Tokenizer {
                 }
             }
             '>' => {
-                if self.peek(1) == Some('=') {
+                if self.peek1() == Some('=') {
                     self.idx += 2;
                     self.tokens.push(Token::Ge);
                     Ok(())
@@ -590,7 +663,7 @@ impl Tokenizer {
                 }
             }
             '<' => {
-                if self.peek(1) == Some('=') {
+                if self.peek1() == Some('=') {
                     self.idx += 2;
                     self.tokens.push(Token::Le);
                     Ok(())
@@ -601,7 +674,7 @@ impl Tokenizer {
                 }
             }
             '?' => {
-                if self.peek(1) == Some('?') {
+                if self.peek1() == Some('?') {
                     self.idx += 2;
                     self.tokens.push(Token::QuestionQuestion);
                 } else {
@@ -620,7 +693,7 @@ impl Tokenizer {
             if self.eof() {
                 break;
             }
-            let c = self.chars[self.idx];
+            let c = self.cur_char().unwrap();
             match c {
                 '"' | '\'' => {
                     self.parse_str()?;
@@ -675,13 +748,13 @@ impl Tokenizer {
             return false;
         }
 
-        let c = self.chars[self.idx];
-        if c.is_ascii_digit() {
+        let b = self.cur_byte();
+        if b.is_ascii_digit() {
             return true;
         }
 
-        if matches!(c, '+' | '-') {
-            return self.peek(1).is_some_and(|next| next.is_ascii_digit());
+        if matches!(b, b'+' | b'-') {
+            return self.peek1().is_some_and(|next| next.is_ascii_digit());
         }
 
         false

--- a/src/token_test.rs
+++ b/src/token_test.rs
@@ -797,10 +797,7 @@ mod tests {
         assert_eq!(t.unwrap(), vec![id("café")]);
 
         let t = Tokenizer::new("@订单.状态");
-        assert_eq!(
-            t.unwrap(),
-            vec![Token::At, id("订单"), Token::Dot, id("状态")]
-        );
+        assert_eq!(t.unwrap(), vec![Token::At, id("订单"), Token::Dot, id("状态")]);
     }
 
     #[test]

--- a/src/token_test.rs
+++ b/src/token_test.rs
@@ -775,4 +775,55 @@ mod tests {
             ]
         );
     }
+
+    // The tokenizer indexes UTF-8 bytes directly; these guard that multibyte
+    // source content (not just \u escapes) advances by full char widths.
+    #[test]
+    fn multibyte_string_literal_content() {
+        let t = Tokenizer::new(r#""你好, мир 🌍""#);
+        assert_eq!(t.unwrap(), vec![str_token("你好, мир 🌍")]);
+    }
+
+    #[test]
+    fn multibyte_string_with_escape() {
+        let t = Tokenizer::new(r#""café\n世界""#);
+        assert_eq!(t.unwrap(), vec![str_token("café\n世界")]);
+    }
+
+    #[test]
+    fn multibyte_unicode_identifier() {
+        // Bare identifiers are Id tokens; unicode letters are valid id chars.
+        let t = Tokenizer::new("café");
+        assert_eq!(t.unwrap(), vec![id("café")]);
+
+        let t = Tokenizer::new("@订单.状态");
+        assert_eq!(
+            t.unwrap(),
+            vec![Token::At, id("订单"), Token::Dot, id("状态")]
+        );
+    }
+
+    #[test]
+    fn multibyte_line_comment() {
+        let t = Tokenizer::new("1 // 中文注释 with 🌍\n+ 2");
+        assert_eq!(t.unwrap(), vec![Token::Int(1), Token::Add, Token::Int(2)]);
+    }
+
+    #[test]
+    fn multibyte_block_comment() {
+        let t = Tokenizer::new("1 /* 嵌套 /* 世界 */ 注释 */ + 2");
+        assert_eq!(t.unwrap(), vec![Token::Int(1), Token::Add, Token::Int(2)]);
+    }
+
+    #[test]
+    fn unterminated_string_with_multibyte_does_not_panic() {
+        // Must return an error, not slice mid-char.
+        assert!(Tokenizer::new(r#""你好"#).is_err());
+    }
+
+    #[test]
+    fn unicode_escape_followed_by_multibyte_does_not_panic() {
+        // \u with fewer than 4 hex digits then a multibyte char: error, no panic.
+        assert!(Tokenizer::new(r#""\u4世界""#).is_err());
+    }
 }


### PR DESCRIPTION
一次性安全/性能审查修复,共 5 项。全量测试 224(单元)+ 20(集成)通过,clippy 干净,所有 feature 组合编译通过。

## 🔴 栈溢出 DoS(安全)
深度守卫原先只保护解析器自身递归,未约束最终 AST 树深度:
- postfix `.` 访问链完全不计数(`nil.a.a…` 约 2 万层即 SIGABRT);
- 括号嵌套(≤128)与二元链(≤256)的乘积可组成约 16 万层的左脊。

`eval` / `fold_constants` / `Drop` / `Debug` 均按树深递归,故全部溢出崩溃(exit 134)。所有入口(CLI / FFI / WASM / Python / `parse_cached`)可触发。

**修复**:把二元链每次迭代与 postfix `Access` 节点纳入统一 `MAX_PARSE_DEPTH` 守卫(`enter_nested` + 新增 `leave_nested_n` 归还,兄弟子树取 max 而非累加),并给 `@` 路径 postfix 分支补段数上限。成功解析的树深度 ≤128,所有递归遍历有界。修复后返回干净解析错误(exit 1)。附 3 个回归测试。

## 🟠 指针地址缓存(正确性)
删除以 `expr as *const _ as usize` 为 key 的 `LITERAL_CONTAINER_CACHE`——地址复用会串回错误求值结果(在 ACL 语境下即错误放行/拒绝);且常量折叠后属死代码。删除后 List/Map 求值省去两次全量扫描。

## 🟡 解析缓存读锁(性能)
缓存命中原本每次拿写锁更新 LRU 时间戳,同 shard 内读被串行化。时间戳改 `AtomicU64`,命中走读锁。

## 🟡 tokenizer 字节化(性能)
从 `Vec<char>`(每字符 4B)改为直接在 UTF-8 字节上索引,消除整份源码的 char 拷贝;标识符与无转义字符串零拷贝切片。多字节字符按整字符宽度前进,新增 7 个多字节源码测试守护。

## 🔵 serde_yaml → serde_yaml_ng(依赖)
serde_yaml 0.9 已停止维护(RUSTSEC-2024-0320),切到维护中的 drop-in fork,`package` 别名保持 crate 名不变,业务代码零改动。

## 未涵盖
no_std(`--no-default-features`)的 3 个报错(缺 allocator / panic handler)是 pre-existing(`git stash` 已确认),属 no_std 库由下游提供运行时的正常情况,不在本 PR 范围。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 提升对多字节字符的支持，可在字符串、标识符及注释中更稳定地处理中文等 UTF-8 内容。
  * 优化表达式解析性能与稳定性，降低复杂表达式处理时的资源开销。

* **错误修复**
  * 复杂或过深的表达式现在会被安全拒绝，并返回明确的深度错误，而不是导致异常或崩溃。
  * 改善多字节字符串及 Unicode 转义错误的处理，避免解析过程中发生崩溃。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->