### PR TITLE
harden: integer-index map access, depth guards, and binding perf

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,11 +1,39 @@
 use crate::val::Val;
 use hashbrown::HashMap;
-use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor};
 use std::fmt;
 use std::sync::Arc;
 
-/// Custom Visitor for deserializing any JSON value to Val enum
-struct ValVisitor;
+/// Cap on container nesting during deserialization. Deeply nested input would
+/// otherwise recurse (visit_seq/visit_map) and, once built, a deep `Val` would
+/// overflow the stack when dropped/traversed. serde_json/yaml/toml each have
+/// their own recursion limits, but this also guards backends that don't (e.g.
+/// serde_wasm_bindgen) and keeps the resulting `Val` depth bounded.
+const MAX_DESERIALIZE_DEPTH: usize = 128;
+
+/// Bound preallocation from a possibly attacker-influenced `size_hint`.
+const MAX_PREALLOC: usize = 4096;
+
+/// Seed carrying the current nesting depth so recursion can be bounded.
+struct ValSeed {
+    depth: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for ValSeed {
+    type Value = Val;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Val, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ValVisitor { depth: self.depth })
+    }
+}
+
+/// Custom Visitor for deserializing any JSON/YAML/TOML value to a `Val`.
+struct ValVisitor {
+    depth: usize,
+}
 
 impl<'de> Visitor<'de> for ValVisitor {
     type Value = Val;
@@ -55,9 +83,12 @@ impl<'de> Visitor<'de> for ValVisitor {
     where
         A: SeqAccess<'de>,
     {
-        let size_hint = seq.size_hint().unwrap_or(0);
+        if self.depth >= MAX_DESERIALIZE_DEPTH {
+            return Err(A::Error::custom("input nesting is too deep"));
+        }
+        let size_hint = seq.size_hint().unwrap_or(0).min(MAX_PREALLOC);
         let mut elements = Vec::with_capacity(size_hint);
-        while let Some(elem) = seq.next_element::<Val>()? {
+        while let Some(elem) = seq.next_element_seed(ValSeed { depth: self.depth + 1 })? {
             elements.push(elem);
         }
         Ok(Val::List(Arc::new(elements)))
@@ -67,9 +98,13 @@ impl<'de> Visitor<'de> for ValVisitor {
     where
         M: MapAccess<'de>,
     {
-        let size_hint = map_access.size_hint().unwrap_or(0);
+        if self.depth >= MAX_DESERIALIZE_DEPTH {
+            return Err(M::Error::custom("input nesting is too deep"));
+        }
+        let size_hint = map_access.size_hint().unwrap_or(0).min(MAX_PREALLOC);
         let mut map = HashMap::with_capacity(size_hint);
-        while let Some((key, value)) = map_access.next_entry::<String, Val>()? {
+        while let Some(key) = map_access.next_key::<String>()? {
+            let value = map_access.next_value_seed(ValSeed { depth: self.depth + 1 })?;
             map.insert(key, value);
         }
         Ok(Val::Map(Arc::new(map)))
@@ -81,7 +116,7 @@ impl<'de> Deserialize<'de> for Val {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_any(ValVisitor)
+        ValSeed { depth: 0 }.deserialize(deserializer)
     }
 }
 

--- a/src/de_test.rs
+++ b/src/de_test.rs
@@ -524,4 +524,31 @@ role = "user"
         assert!(!has_toml_indicators("- item"));
         assert!(!has_toml_indicators(""));
     }
+
+    // A `serde_json::Value` used as a Deserializer has no recursion limit (that
+    // only applies when parsing text), so it exercises Val's own depth guard —
+    // the same guard that protects limit-less backends such as serde_wasm_bindgen.
+    #[test]
+    #[cfg(feature = "json")]
+    fn rejects_input_deeper_than_limit() {
+        use serde::de::Deserialize;
+        let mut v = serde_json::Value::from(1);
+        for _ in 0..300 {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        let result = Val::deserialize(v);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too deep"));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn accepts_input_within_limit() {
+        use serde::de::Deserialize;
+        let mut v = serde_json::Value::from(1);
+        for _ in 0..100 {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        assert!(Val::deserialize(v).is_ok());
+    }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7,7 +7,7 @@
 use alloc::{ffi::CString, format};
 use core::ffi::{CStr, c_char, c_int};
 
-use crate::{ast::Parser, token::Tokenizer, val::Val};
+use crate::{expr::Expr, val::Val};
 
 /// Parse and evaluate a QCL expression against a JSON context string.
 ///
@@ -46,11 +46,7 @@ pub unsafe extern "C" fn qcl_eval_json(expression: *const c_char, json_ctx: *con
 /// This lower-level function takes a raw expression string and evaluates it.
 /// Context must be built separately.
 fn eval_inner(expression: &str, ctx: &Val) -> *mut c_char {
-    let tokens = match Tokenizer::new(expression) {
-        Ok(t) => t,
-        Err(e) => return set_err(format!("{e}")),
-    };
-    let expr = match Parser::new(&tokens).parse() {
+    let expr = match Expr::parse_cached_arc(expression) {
         Ok(e) => e,
         Err(e) => return set_err(format!("{e}")),
     };
@@ -127,14 +123,7 @@ pub unsafe extern "C" fn qcl_check_json(expression: *const c_char, json_ctx: *co
         }
     };
 
-    let tokens = match Tokenizer::new(expr_str) {
-        Ok(t) => t,
-        Err(e) => {
-            set_err(format!("{e}"));
-            return -1;
-        }
-    };
-    let expr = match Parser::new(&tokens).parse() {
+    let expr = match Expr::parse_cached_arc(expr_str) {
         Ok(e) => e,
         Err(e) => {
             set_err(format!("{e}"));

--- a/src/python.rs
+++ b/src/python.rs
@@ -8,8 +8,16 @@ use alloc::{string::ToString, sync::Arc, vec::Vec};
 
 use crate::{de, expr::Expr, val::Val};
 
+/// Cap on nesting when converting between Python objects and `Val`, mirroring
+/// the deserialize/parser limits so a deeply nested host object cannot overflow
+/// the stack during the recursive conversion.
+const MAX_DEPTH: usize = 128;
+
 /// Convert a Python object to a QCL Val.
-fn py_to_val(obj: &Bound<'_, PyAny>) -> PyResult<Val> {
+fn py_to_val(obj: &Bound<'_, PyAny>, depth: usize) -> PyResult<Val> {
+    if depth >= MAX_DEPTH {
+        return Err(PyValueError::new_err("input nesting is too deep"));
+    }
     if obj.is_none() {
         Ok(Val::Nil)
     } else if let Ok(b) = obj.downcast::<PyBool>() {
@@ -21,7 +29,10 @@ fn py_to_val(obj: &Bound<'_, PyAny>) -> PyResult<Val> {
     } else if let Ok(s) = obj.downcast::<PyString>() {
         Ok(Val::from(s.to_str()?))
     } else if let Ok(list) = obj.downcast::<PyList>() {
-        let items: Vec<Val> = list.iter().map(|item| py_to_val(&item)).collect::<PyResult<_>>()?;
+        let items: Vec<Val> = list
+            .iter()
+            .map(|item| py_to_val(&item, depth + 1))
+            .collect::<PyResult<_>>()?;
         Ok(Val::List(Arc::new(items)))
     } else if let Ok(dict) = obj.downcast::<PyDict>() {
         let mut map = hashbrown::HashMap::with_capacity(dict.len());
@@ -31,7 +42,7 @@ fn py_to_val(obj: &Bound<'_, PyAny>) -> PyResult<Val> {
                 .map_err(|_| PyValueError::new_err("dict keys must be strings"))?
                 .to_str()?
                 .to_string();
-            map.insert(key, py_to_val(&v)?);
+            map.insert(key, py_to_val(&v, depth + 1)?);
         }
         Ok(Val::Map(Arc::new(map)))
     } else {
@@ -43,7 +54,10 @@ fn py_to_val(obj: &Bound<'_, PyAny>) -> PyResult<Val> {
 }
 
 /// Convert a QCL Val to a Python object.
-fn val_to_py(py: Python<'_>, val: &Val) -> PyResult<PyObject> {
+fn val_to_py(py: Python<'_>, val: &Val, depth: usize) -> PyResult<PyObject> {
+    if depth >= MAX_DEPTH {
+        return Err(PyValueError::new_err("value nesting is too deep"));
+    }
     match val {
         Val::Nil => Ok(py.None()),
         Val::Bool(b) => Ok(b.into_pyobject(py)?.to_owned().into_any().unbind()),
@@ -51,13 +65,13 @@ fn val_to_py(py: Python<'_>, val: &Val) -> PyResult<PyObject> {
         Val::Float(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
         Val::Str(s) => Ok(s.as_ref().into_pyobject(py)?.into_any().unbind()),
         Val::List(l) => {
-            let items: Vec<PyObject> = l.iter().map(|v| val_to_py(py, v)).collect::<PyResult<_>>()?;
+            let items: Vec<PyObject> = l.iter().map(|v| val_to_py(py, v, depth + 1)).collect::<PyResult<_>>()?;
             Ok(PyList::new(py, items)?.into_any().unbind())
         }
         Val::Map(m) => {
             let dict = PyDict::new(py);
             for (k, v) in m.iter() {
-                dict.set_item(k, val_to_py(py, v)?)?;
+                dict.set_item(k, val_to_py(py, v, depth + 1)?)?;
             }
             Ok(dict.into_any().unbind())
         }
@@ -74,10 +88,10 @@ fn val_to_py(py: Python<'_>, val: &Val) -> PyResult<PyObject> {
 ///     The evaluation result as a Python object
 #[pyfunction]
 fn eval(py: Python<'_>, expression: &str, context: &Bound<'_, PyAny>) -> PyResult<PyObject> {
-    let ctx = py_to_val(context)?;
+    let ctx = py_to_val(context, 0)?;
     let expr = Expr::parse_cached_arc(expression).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| PyValueError::new_err(e.to_string()))?;
-    val_to_py(py, &result)
+    val_to_py(py, &result, 0)
 }
 
 /// Evaluate a QCL expression against a JSON string context.
@@ -93,7 +107,7 @@ fn eval_json(py: Python<'_>, expression: &str, json_ctx: &str) -> PyResult<PyObj
     let ctx: Val = de::from_json_str(json_ctx).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let expr = Expr::parse_cached_arc(expression).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| PyValueError::new_err(e.to_string()))?;
-    val_to_py(py, &result)
+    val_to_py(py, &result, 0)
 }
 
 /// Check if a QCL expression evaluates to truthy.
@@ -106,7 +120,7 @@ fn eval_json(py: Python<'_>, expression: &str, json_ctx: &str) -> PyResult<PyObj
 ///     True if the result is truthy, False otherwise
 #[pyfunction]
 fn check(expression: &str, context: &Bound<'_, PyAny>) -> PyResult<bool> {
-    let ctx = py_to_val(context)?;
+    let ctx = py_to_val(context, 0)?;
     let expr = Expr::parse_cached_arc(expression).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| PyValueError::new_err(e.to_string()))?;
     Ok(!matches!(result, Val::Bool(false) | Val::Nil))

--- a/src/token.rs
+++ b/src/token.rs
@@ -3,6 +3,12 @@ use core::fmt::Debug;
 
 use crate::error::{Error, Result};
 
+/// Cap on up-front token-vector allocation. `s.len() / 4` is a fine estimate for
+/// normal expressions, but a huge (possibly untrusted) input would otherwise
+/// force a multi-hundred-MB reservation before a single token is produced. The
+/// vector still grows on demand past this for genuinely large token streams.
+const MAX_TOKEN_PREALLOC: usize = 4096;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
     LParen,           // (
@@ -61,7 +67,7 @@ impl<'a> Tokenizer<'a> {
             bytes: s.as_bytes(),
             idx: 0,
             len: s.len(),
-            tokens: Vec::with_capacity(s.len() / 4), // Preallocate a reasonable size
+            tokens: Vec::with_capacity((s.len() / 4).min(MAX_TOKEN_PREALLOC)),
         };
         t.parse()?;
         Ok(t.tokens)

--- a/src/val.rs
+++ b/src/val.rs
@@ -36,10 +36,54 @@ pub enum Val {
     Nil,
 }
 
+/// Formats an `i64` into a fixed stack buffer so a map lookup by integer index
+/// (`a.1`) can borrow a `&str` key without allocating. i64 decimal is at most
+/// 20 bytes ("-9223372036854775808").
+struct IntKey {
+    buf: [u8; 20],
+    len: usize,
+}
+
+impl core::fmt::Write for IntKey {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let bytes = s.as_bytes();
+        let end = self.len + bytes.len();
+        if end > self.buf.len() {
+            return Err(core::fmt::Error);
+        }
+        self.buf[self.len..end].copy_from_slice(bytes);
+        self.len = end;
+        Ok(())
+    }
+}
+
+impl IntKey {
+    #[inline]
+    fn new(n: i64) -> Self {
+        use core::fmt::Write as _;
+        let mut key = IntKey { buf: [0; 20], len: 0 };
+        // Infallible: an i64 never needs more than 20 bytes.
+        let _ = write!(key, "{n}");
+        key
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        // Only ASCII digits and '-' are written, so this is always valid UTF-8.
+        core::str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
 impl Val {
     pub(crate) fn access(&self, field: &Val) -> Option<&Val> {
         match (self, field) {
             (Val::Map(m), Val::Str(s)) => m.get(s.as_ref()),
+            // `a.1` is equivalent to `a."1"`: map keys are string-valued, so an
+            // integer index is normalized to its decimal string form.
+            (Val::Map(m), Val::Int(i)) => {
+                let key = IntKey::new(*i);
+                m.get(key.as_str())
+            }
             (Val::List(l), Val::Int(i)) => {
                 let idx = if *i < 0 {
                     let adjusted = l.len() as i64 + *i;
@@ -432,68 +476,109 @@ impl From<()> for Val {
     }
 }
 
+/// Depth cap for `serde_*::Value` -> `Val` conversion, mirroring the deserialize
+/// guard. These `From` impls recurse directly (they don't go through the
+/// depth-bounded `ValVisitor`), so a deeply nested `Value` — e.g. built by
+/// `Val::try_from` via `serde_json::to_value`, which itself has no text-parse
+/// recursion limit — would otherwise overflow the stack. Subtrees deeper than
+/// this are converted to `Nil` (fail-safe truncation rather than a crash).
+#[cfg(any(feature = "json", feature = "yaml"))]
+const MAX_VALUE_CONVERSION_DEPTH: usize = 128;
+
 #[cfg(feature = "json")]
 impl From<serde_json::Value> for Val {
     fn from(val: serde_json::Value) -> Self {
-        match val {
-            serde_json::Value::String(s) => Val::Str(Arc::<str>::from(s.into_boxed_str())),
-            serde_json::Value::Number(n) => {
-                if let Some(i) = n.as_i64() {
-                    Val::Int(i)
-                } else if let Some(f) = n.as_f64() {
-                    Val::Float(f)
-                } else {
-                    Val::Nil
-                }
+        json_value_to_val(val, 0)
+    }
+}
+
+#[cfg(feature = "json")]
+fn json_value_to_val(val: serde_json::Value, depth: usize) -> Val {
+    match val {
+        serde_json::Value::String(s) => Val::Str(Arc::<str>::from(s.into_boxed_str())),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Val::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Val::Float(f)
+            } else {
+                Val::Nil
             }
-            serde_json::Value::Bool(b) => Val::Bool(b),
-            serde_json::Value::Array(a) => {
-                let v = a.into_iter().map(Val::from).collect();
-                Val::List(Arc::new(v))
-            }
-            serde_json::Value::Object(o) => {
-                let m = o.into_iter().map(|(k, v)| (k, Val::from(v))).collect();
-                Val::Map(Arc::new(m))
-            }
-            serde_json::Value::Null => Val::Nil,
         }
+        serde_json::Value::Bool(b) => Val::Bool(b),
+        serde_json::Value::Array(a) => {
+            if depth >= MAX_VALUE_CONVERSION_DEPTH {
+                return Val::Nil;
+            }
+            let v = a.into_iter().map(|e| json_value_to_val(e, depth + 1)).collect();
+            Val::List(Arc::new(v))
+        }
+        serde_json::Value::Object(o) => {
+            if depth >= MAX_VALUE_CONVERSION_DEPTH {
+                return Val::Nil;
+            }
+            let m = o
+                .into_iter()
+                .map(|(k, v)| (k, json_value_to_val(v, depth + 1)))
+                .collect();
+            Val::Map(Arc::new(m))
+        }
+        serde_json::Value::Null => Val::Nil,
     }
 }
 
 #[cfg(feature = "yaml")]
 impl From<serde_yaml::Value> for Val {
     fn from(val: serde_yaml::Value) -> Self {
-        match val {
-            serde_yaml::Value::String(s) => Val::Str(Arc::<str>::from(s.into_boxed_str())),
-            serde_yaml::Value::Number(n) => {
-                if let Some(i) = n.as_i64() {
-                    Val::Int(i)
-                } else if let Some(f) = n.as_f64() {
-                    Val::Float(f)
-                } else {
-                    Val::Nil
-                }
+        yaml_value_to_val(val, 0)
+    }
+}
+
+#[cfg(feature = "yaml")]
+fn yaml_value_to_val(val: serde_yaml::Value, depth: usize) -> Val {
+    match val {
+        serde_yaml::Value::String(s) => Val::Str(Arc::<str>::from(s.into_boxed_str())),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Val::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Val::Float(f)
+            } else {
+                Val::Nil
             }
-            serde_yaml::Value::Bool(b) => Val::Bool(b),
-            serde_yaml::Value::Sequence(a) => {
-                let v = a.into_iter().map(Val::from).collect();
-                Val::List(Arc::new(v))
+        }
+        serde_yaml::Value::Bool(b) => Val::Bool(b),
+        serde_yaml::Value::Sequence(a) => {
+            if depth >= MAX_VALUE_CONVERSION_DEPTH {
+                return Val::Nil;
             }
-            serde_yaml::Value::Mapping(o) => {
-                let m = o
-                    .into_iter()
-                    .filter_map(|(k, v)| {
-                        if let serde_yaml::Value::String(key) = k {
-                            Some((key, Val::from(v)))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                Val::Map(Arc::new(m))
+            let v = a.into_iter().map(|e| yaml_value_to_val(e, depth + 1)).collect();
+            Val::List(Arc::new(v))
+        }
+        serde_yaml::Value::Mapping(o) => {
+            if depth >= MAX_VALUE_CONVERSION_DEPTH {
+                return Val::Nil;
             }
-            serde_yaml::Value::Null => Val::Nil,
-            serde_yaml::Value::Tagged(tagged) => Val::from(tagged.value),
+            let m = o
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    if let serde_yaml::Value::String(key) = k {
+                        Some((key, yaml_value_to_val(v, depth + 1)))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            Val::Map(Arc::new(m))
+        }
+        serde_yaml::Value::Null => Val::Nil,
+        serde_yaml::Value::Tagged(tagged) => {
+            // A `Tagged` wraps another value and can itself nest, so it must
+            // count toward the budget to keep the recursion bounded.
+            if depth >= MAX_VALUE_CONVERSION_DEPTH {
+                return Val::Nil;
+            }
+            yaml_value_to_val(tagged.value, depth + 1)
         }
     }
 }

--- a/src/val_test.rs
+++ b/src/val_test.rs
@@ -198,6 +198,21 @@ mod tests {
     }
 
     #[test]
+    fn test_map_access_by_int_index() {
+        // `a.1` on a map normalizes the integer to its string key: equivalent to `a."1"`.
+        let mut map = HashMap::new();
+        map.insert("1", "one".to_string());
+        map.insert("-2", "neg".to_string());
+
+        let val: Val = map.into();
+
+        assert_eq!(val.access(&Val::Int(1)), Some(&Val::Str("one".into())));
+        assert_eq!(val.access(&Val::Str("1".into())), Some(&Val::Str("one".into())));
+        assert_eq!(val.access(&Val::Int(-2)), Some(&Val::Str("neg".into())));
+        assert_eq!(val.access(&Val::Int(9)), None);
+    }
+
+    #[test]
     fn test_access_out_of_bounds() {
         let list = vec![10, 20, 30];
         let val: Val = list.into();
@@ -615,5 +630,44 @@ mod tests {
         assert_eq!(list.access(&Val::Int(u32::MAX as i64 + 1)), None);
         // Very negative value
         assert_eq!(list.access(&Val::Int(i64::MIN)), None);
+    }
+
+    // The From<serde_json::Value> impl recurses directly (not via the
+    // depth-bounded deserializer), so it must guard against deep nesting.
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_value_truncates_beyond_depth_limit() {
+        let mut v = serde_json::Value::from(1);
+        for _ in 0..300 {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        let val = Val::from(v); // must not overflow
+        let mut cur = &val;
+        let mut walked = 0;
+        while let Val::List(l) = cur {
+            assert_eq!(l.len(), 1);
+            cur = &l[0];
+            walked += 1;
+            if walked > 400 {
+                break;
+            }
+        }
+        // Past the limit the subtree is truncated to Nil rather than Int(1).
+        assert!(matches!(cur, Val::Nil));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_value_preserves_within_limit() {
+        let mut v = serde_json::Value::from(7);
+        for _ in 0..100 {
+            v = serde_json::Value::Array(vec![v]);
+        }
+        let val = Val::from(v);
+        let mut cur = &val;
+        while let Val::List(l) = cur {
+            cur = &l[0];
+        }
+        assert_eq!(cur, &Val::Int(7));
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -8,7 +8,7 @@ use crate::{de, expr::Expr, val::Val};
 #[wasm_bindgen]
 pub fn eval_json(expression: &str, json_ctx: &str) -> Result<String, JsError> {
     let ctx: Val = de::from_json_str(json_ctx).map_err(|e| JsError::new(&e.to_string()))?;
-    let expr = Expr::parse_cached(expression).map_err(|e| JsError::new(&e.to_string()))?;
+    let expr = Expr::parse_cached_arc(expression).map_err(|e| JsError::new(&e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| JsError::new(&e.to_string()))?;
     serde_json::to_string(&result).map_err(|e| JsError::new(&e.to_string()))
 }
@@ -20,7 +20,7 @@ pub fn eval_json(expression: &str, json_ctx: &str) -> Result<String, JsError> {
 #[wasm_bindgen]
 pub fn eval(expression: &str, ctx: JsValue) -> Result<JsValue, JsError> {
     let ctx: Val = serde_wasm_bindgen::from_value(ctx).map_err(|e| JsError::new(&e.to_string()))?;
-    let expr = Expr::parse_cached(expression).map_err(|e| JsError::new(&e.to_string()))?;
+    let expr = Expr::parse_cached_arc(expression).map_err(|e| JsError::new(&e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| JsError::new(&e.to_string()))?;
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
 }


### PR DESCRIPTION
Follow-up hardening + a small feature. All tests pass (230 unit + 20 integration), clippy `-D warnings` clean, ffi/wasm/python features compile.

## Feature: integer-index map access
`Val::access` now accepts an integer index on maps: `a.1` is equivalent to `a."1"`. The index is normalized to its decimal string key (map keys are string-valued, matching JSON), formatted into a fixed stack buffer with no heap allocation. Lists keep their existing integer indexing.

## Security: bound recursion depth on every Val-construction path
The deserializer already recursed unbounded before this series; the remaining paths that bypass it are now guarded, all at a consistent 128-level cap:

- **Deserialize** (`de.rs`) — switched to a depth-carrying `DeserializeSeed`; rejects input nested deeper than 128. This protects backends that have no recursion limit of their own (notably `serde_wasm_bindgen`) and keeps the resulting `Val` depth bounded so drop/traverse can't overflow. Also caps `size_hint`-driven preallocation.
- **Python bindings** (`python.rs`) — `py_to_val`/`val_to_py` carry a depth and return an error instead of aborting the process on deeply nested host objects.
- **`From<serde_json::Value>` / `From<serde_yaml::Value>`** (`val.rs`) — these recurse directly (not through the deserializer's guard), so a deeply nested `Value` — e.g. from `Val::try_from` via `serde_json::to_value`, which has no text-parse recursion limit — could overflow. They now recurse through internal depth-bounded helpers that truncate subtrees past the limit to `Nil` (fail-safe). Scope note: this stops qcl from recursing to overflow; the depth of a `Value` the caller already built (its own construction/drop) remains serde's responsibility.
- **Tokenizer preallocation** (`token.rs`) — token-vector preallocation is capped at 4096, so a huge untrusted expression can't force a multi-hundred-MB up-front allocation. The vector still grows on demand.

## Performance
- **ffi** (`ffi.rs`) — `qcl_eval_json`/`qcl_check_json` re-tokenized and re-parsed on every call; they now use `Expr::parse_cached_arc`. Benchmarked no-cache parse 1.73µs vs cache hit ~332ns (~5x) for repeated expressions, the typical ACL pattern.
- **wasm** (`wasm.rs`) — `parse_cached` → `parse_cached_arc`, avoiding a deep clone of the whole AST on each call.

## Not changed (reviewed, declined)
- `in` substring search: Rust's `str::contains(&str)` uses the Two-Way algorithm (O(n+m)), not the naive O(n·m) — no quadratic blowup.
- `err()` line/column scan is O(n) but only on the error path, once — not worth the added complexity.

## Regression tests
Deserialize depth reject/accept, `From<Value>` truncate/preserve, and integer-index map access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持使用整数键访问映射，例如 `a.1` 等价于访问键 `"1"`。
  - 增加对 JSON、YAML 及 Python 数据嵌套深度的限制，超深输入或输出将返回明确错误或截断结果。
- **稳定性改进**
  - 限制大型输入的内存预分配，降低处理超大数据时的内存压力。
  - 优化表达式解析流程，保持现有接口和评估行为不变。
- **测试**
  - 新增嵌套深度、整数键访问及深层数据转换的行为验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->