### PR TITLE
perf: context parse reuse, top-level filtering & Val serializer

### DIFF
--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -54,11 +54,13 @@ fn bench_parsing(c: &mut Criterion) {
         })
     });
 
-    // Parsing with cache (warm up cache then repeatedly parse same expression)
-    let _ = Expr::parse_cached(expr_str).unwrap(); // Warm up cache
+    // Parsing with cache (warm up cache then repeatedly parse same expression).
+    // Uses parse_cached_arc - the path every binding takes - so this reflects
+    // the real cache-hit cost, not the AST deep-clone that parse_cached performs.
+    let _ = Expr::parse_cached_arc(expr_str).unwrap(); // Warm up cache
     c.bench_function("parse_with_cache", |b| {
         b.iter(|| {
-            let expr = Expr::parse_cached(expr_str).unwrap();
+            let expr = Expr::parse_cached_arc(expr_str).unwrap();
             black_box(&expr);
         })
     });
@@ -444,6 +446,59 @@ fn bench_ternary_coalesce(c: &mut Criterion) {
     });
 }
 
+// Benchmark 11: Context parsing - full vs top-level-filtered (方向4)
+fn bench_context_parsing(c: &mut Criterion) {
+    // A large context where a typical ACL check only touches `user`.
+    let mut big = String::from("{\"user\":{\"role\":\"admin\",\"age\":18},\"biglist\":[");
+    for i in 0..1000u32 {
+        if i > 0 {
+            big.push(',');
+        }
+        big.push_str(&i.to_string());
+    }
+    big.push_str("],\"bigmap\":{");
+    for i in 0..100u32 {
+        if i > 0 {
+            big.push(',');
+        }
+        big.push_str(&format!("\"key{i}\":{i}"));
+    }
+    big.push_str("}}");
+
+    let mut keep = hashbrown::HashSet::new();
+    keep.insert("user".to_string());
+
+    c.bench_function("ctx_parse_full", |b| {
+        b.iter(|| {
+            let v = qcl::de::from_json_str(&big).unwrap();
+            black_box(&v);
+        })
+    });
+
+    c.bench_function("ctx_parse_filtered", |b| {
+        b.iter(|| {
+            let v = qcl::de::from_json_str_keep(&big, &keep).unwrap();
+            black_box(&v);
+        })
+    });
+
+    // End-to-end: parse ctx + parse expr + eval, full vs filtered.
+    c.bench_function("e2e_pipeline_full", |b| {
+        b.iter(|| {
+            let ctx = qcl::de::from_json_str(&big).unwrap();
+            let e = Expr::parse_cached_arc("@user.role").unwrap();
+            black_box(e.eval(&ctx).unwrap());
+        })
+    });
+    c.bench_function("e2e_pipeline_filtered", |b| {
+        b.iter(|| {
+            let ctx = qcl::de::from_json_str_keep(&big, &keep).unwrap();
+            let e = Expr::parse_cached_arc("@user.role").unwrap();
+            black_box(e.eval(&ctx).unwrap());
+        })
+    });
+}
+
 // Criterion benchmark group definition
 criterion_group!(
     benches,
@@ -456,6 +511,7 @@ criterion_group!(
     bench_string_operations,
     bench_memory_allocation,
     bench_complex_arithmetic,
-    bench_ternary_coalesce
+    bench_ternary_coalesce,
+    bench_context_parsing
 );
 criterion_main!(benches);

--- a/src/de.rs
+++ b/src/de.rs
@@ -189,7 +189,10 @@ pub fn from_json_str_keep(input: &str, keep: &HashSet<String>) -> crate::error::
     } else {
         de.deserialize_map(FilteredMapVisitor { depth: 0, keep })
     };
-    result.map_err(|e| crate::error::Error::Deserialize(e.to_string()))
+    let val = result.map_err(|e| crate::error::Error::Deserialize(e.to_string()))?;
+    // Reject trailing non-whitespace, matching serde_json::from_str semantics.
+    de.end().map_err(|e| crate::error::Error::Deserialize(e.to_string()))?;
+    Ok(val)
 }
 
 /// Parse JSON into a `Val`, keeping only the top-level keys referenced by any

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,9 @@
 use crate::val::Val;
-use hashbrown::HashMap;
-use serde::de::{Deserialize, DeserializeSeed, Deserializer, Error as DeError, MapAccess, SeqAccess, Visitor};
+use hashbrown::{HashMap, HashSet};
+use serde::de::{
+    Deserialize, DeserializeSeed, Deserializer, Error as DeError, IgnoredAny, MapAccess, SeqAccess,
+    Visitor,
+};
 use std::fmt;
 use std::sync::Arc;
 
@@ -111,6 +114,43 @@ impl<'de> Visitor<'de> for ValVisitor {
     }
 }
 
+/// Top-level map visitor that drops entries whose key is not in `keep`.
+/// Nested values reuse the regular [`ValVisitor`] (no filtering below the top
+/// level). Used by [`from_json_str_keep`].
+struct FilteredMapVisitor<'a> {
+    depth: usize,
+    keep: &'a HashSet<String>,
+}
+
+impl<'de> Visitor<'de> for FilteredMapVisitor<'_> {
+    type Value = Val;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a JSON object")
+    }
+
+    fn visit_map<M>(self, mut map_access: M) -> Result<Val, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        if self.depth >= MAX_DESERIALIZE_DEPTH {
+            return Err(M::Error::custom("input nesting is too deep"));
+        }
+        let mut map =
+            HashMap::with_capacity(map_access.size_hint().unwrap_or(0).min(MAX_PREALLOC));
+        while let Some(key) = map_access.next_key::<String>()? {
+            if self.keep.contains(&key) {
+                let value = map_access.next_value_seed(ValSeed { depth: self.depth + 1 })?;
+                map.insert(key, value);
+            } else {
+                // Skip the value without building a Val for it.
+                let _: IgnoredAny = map_access.next_value()?;
+            }
+        }
+        Ok(Val::Map(Arc::new(map)))
+    }
+}
+
 impl<'de> Deserialize<'de> for Val {
     fn deserialize<D>(deserializer: D) -> Result<Val, D::Error>
     where
@@ -124,6 +164,49 @@ impl<'de> Deserialize<'de> for Val {
 #[cfg(feature = "json")]
 pub fn from_json_str(input: &str) -> crate::error::Result<Val> {
     serde_json::from_str::<Val>(input).map_err(|e| crate::error::Error::Deserialize(e.to_string()))
+}
+
+/// Parse JSON into a `Val`, keeping only the top-level keys listed in `keep`.
+///
+/// Values under skipped top-level keys are not materialized - they are parsed
+/// with `IgnoredAny` - so a large context where an expression references only
+/// a few top-level fields avoids most of the allocation cost. Filtering is
+/// top-level only; nested maps are parsed in full.
+///
+/// If `keep` is empty, or the top level is not a JSON object, no filtering is
+/// applied (full parse). The empty-keep default prevents a caller from
+/// accidentally dropping every field.
+#[cfg(feature = "json")]
+pub fn from_json_str_keep(input: &str, keep: &HashSet<String>) -> crate::error::Result<Val> {
+    let mut de = serde_json::Deserializer::from_str(input);
+    let is_object = input
+        .trim_start()
+        .as_bytes()
+        .first()
+        .is_some_and(|&b| b == b'{');
+    let result = if keep.is_empty() || !is_object {
+        de.deserialize_any(ValVisitor { depth: 0 })
+    } else {
+        de.deserialize_map(FilteredMapVisitor { depth: 0, keep })
+    };
+    result.map_err(|e| crate::error::Error::Deserialize(e.to_string()))
+}
+
+/// Parse JSON into a `Val`, keeping only the top-level keys referenced by any
+/// of `exprs` (via [`crate::expr::Expr::requested_ctx`]). Convenience wrapper
+/// over [`from_json_str_keep`] that merges the context names from all expressions.
+#[cfg(feature = "json")]
+pub fn from_json_str_for_exprs(
+    input: &str,
+    exprs: &[&crate::expr::Expr],
+) -> crate::error::Result<Val> {
+    let mut keep = HashSet::new();
+    for expr in exprs {
+        for name in expr.requested_ctx() {
+            keep.insert(name);
+        }
+    }
+    from_json_str_keep(input, &keep)
 }
 
 /// Direct YAML string to Val conversion avoiding intermediate serde_yaml::Value

--- a/src/de_test.rs
+++ b/src/de_test.rs
@@ -551,4 +551,78 @@ role = "user"
         }
         assert!(Val::deserialize(v).is_ok());
     }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_keep_filters_top_level() {
+        use hashbrown::HashSet;
+        let json = r#"{"a":1,"b":{"x":2},"c":[1,2,3],"d":"skip"}"#;
+        let mut keep = HashSet::new();
+        keep.insert("b".to_string());
+        let val = from_json_str_keep(json, &keep).unwrap();
+        let m = match val {
+            Val::Map(m) => m,
+            _ => panic!("expected map"),
+        };
+        assert_eq!(m.len(), 1);
+        assert!(m.contains_key("b"));
+        assert!(!m.contains_key("a"));
+        // nested b.x is still parsed in full (filtering is top-level only)
+        assert!(matches!(m.get("b"), Some(Val::Map(_))));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_keep_empty_parses_fully() {
+        use hashbrown::HashSet;
+        let json = r#"{"a":1,"b":2}"#;
+        let keep = HashSet::<String>::new();
+        let val = from_json_str_keep(json, &keep).unwrap();
+        assert!(matches!(val, Val::Map(m) if m.len() == 2));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_keep_non_object_parses_fully() {
+        use hashbrown::HashSet;
+        let json = r#"[1,2,3]"#;
+        let mut keep = HashSet::new();
+        keep.insert("a".to_string());
+        let val = from_json_str_keep(json, &keep).unwrap();
+        assert!(matches!(val, Val::List(l) if l.len() == 3));
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_keep_preserves_eval_semantics() {
+        use crate::expr::Expr;
+        use hashbrown::HashSet;
+        let json = r#"{"user":{"role":"admin"},"big":"unused"}"#;
+        let mut keep = HashSet::new();
+        keep.insert("user".to_string());
+        let ctx = from_json_str_keep(json, &keep).unwrap();
+        let expr = Expr::try_from("@user.role").unwrap();
+        assert_eq!(expr.eval(&ctx).unwrap(), Val::Str(Arc::from("admin")));
+        // a pruned key behaves like a missing key (Nil)
+        let expr2 = Expr::try_from("@big").unwrap();
+        assert_eq!(expr2.eval(&ctx).unwrap(), Val::Nil);
+    }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_for_exprs_merges_names() {
+        use crate::expr::Expr;
+        let json = r#"{"a":1,"b":2,"c":3,"d":4}"#;
+        let e1 = Expr::try_from("@a + @b").unwrap();
+        let e2 = Expr::try_from("@c").unwrap();
+        let ctx = from_json_str_for_exprs(json, &[&e1, &e2]).unwrap();
+        match ctx {
+            Val::Map(m) => {
+                assert_eq!(m.len(), 3);
+                assert!(m.contains_key("a") && m.contains_key("b") && m.contains_key("c"));
+                assert!(!m.contains_key("d"));
+            }
+            _ => panic!("expected map"),
+        }
+    }
 }

--- a/src/de_test.rs
+++ b/src/de_test.rs
@@ -625,4 +625,19 @@ role = "user"
             _ => panic!("expected map"),
         }
     }
+
+    #[test]
+    #[cfg(feature = "json")]
+    fn from_json_str_keep_rejects_trailing_garbage() {
+        use hashbrown::HashSet;
+        // Trailing non-whitespace must be rejected, matching from_json_str.
+        let mut keep = HashSet::new();
+        keep.insert("a".to_string());
+        assert!(from_json_str_keep(r#"{"a":1}xxx"#, &keep).is_err());
+        // Empty keep (full-parse path) must also reject.
+        let empty = HashSet::<String>::new();
+        assert!(from_json_str_keep(r#"{"a":1}xxx"#, &empty).is_err());
+        // Sanity: clean input still parses.
+        assert!(from_json_str_keep(r#"{"a":1}"#, &keep).is_ok());
+    }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -121,16 +121,17 @@ struct CacheEntry {
 #[cfg(feature = "std")]
 struct ParseCacheState {
     entries: HashMap<String, CacheEntry>,
+    /// Per-shard LRU clock. Local to the shard (not a global static) so hits
+    /// don't bounce a single cache line across all 16 shards.
+    clock: AtomicU64,
 }
-
-#[cfg(feature = "std")]
-static CACHE_CLOCK: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(feature = "std")]
 impl ParseCacheState {
     fn new() -> Self {
         Self {
             entries: HashMap::new(),
+            clock: AtomicU64::new(0),
         }
     }
 
@@ -139,11 +140,16 @@ impl ParseCacheState {
     /// shared lock and never serializes readers within a shard.
     fn get(&self, expression: &str) -> Option<Arc<Expr>> {
         let entry = self.entries.get(expression)?;
+        // LRU timestamps only matter once the shard is near capacity (evictions
+        // only happen at full). Skip the two atomics on every hit while there
+        // is still room - the common case when the working set fits comfortably.
         // fetch_max keeps last_used monotonic: two readers racing under the
         // shared lock cannot let an earlier ticket overwrite a later one's.
-        entry
-            .last_used
-            .fetch_max(CACHE_CLOCK.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
+        if self.entries.len() >= parse_cache_entries_per_shard() * 3 / 4 {
+            entry
+                .last_used
+                .fetch_max(self.clock.fetch_add(1, Ordering::Relaxed), Ordering::Relaxed);
+        }
         Some(entry.expr.clone())
     }
 
@@ -156,7 +162,7 @@ impl ParseCacheState {
             self.evict_oldest();
         }
 
-        let ts = CACHE_CLOCK.fetch_add(1, Ordering::Relaxed);
+        let ts = self.clock.fetch_add(1, Ordering::Relaxed);
         self.entries.insert(
             expression,
             CacheEntry {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -116,7 +116,6 @@ pub unsafe extern "C" fn qcl_eval_ctx(expression: *const c_char, ctx: *const Val
 ///
 /// # Safety
 /// - `expression` and `ctx` must be valid, non-null; `ctx` from `qcl_parse_ctx`.
-#[cfg(feature = "json")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qcl_check_ctx(expression: *const c_char, ctx: *const Val) -> c_int {
     if expression.is_null() {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -56,6 +56,117 @@ fn eval_inner(expression: &str, ctx: &Val) -> *mut c_char {
     }
 }
 
+/// Parse a JSON context string into an opaque `Val` handle.
+///
+/// The returned handle can be passed to `qcl_eval_ctx` / `qcl_check_ctx` any
+/// number of times, amortizing the JSON parse across many evaluations. The
+/// caller must free it with `qcl_free_ctx` when done.
+///
+/// # Safety
+/// - `json_ctx` must be a valid, non-null, null-terminated C string.
+/// - Returns null on error; call `qcl_last_error` for the message.
+#[cfg(feature = "json")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qcl_parse_ctx(json_ctx: *const c_char) -> *mut Val {
+    if json_ctx.is_null() {
+        set_err("null json_ctx pointer".to_string());
+        return core::ptr::null_mut();
+    }
+    let ctx_str = match unsafe { CStr::from_ptr(json_ctx) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_err(format!("invalid json_ctx UTF-8: {e}"));
+            return core::ptr::null_mut();
+        }
+    };
+    match crate::de::from_json_str(ctx_str) {
+        Ok(v) => Box::into_raw(Box::new(v)),
+        Err(e) => {
+            set_err(format!("{e}"));
+            core::ptr::null_mut()
+        }
+    }
+}
+
+/// Evaluate a QCL expression against a pre-parsed context handle.
+///
+/// # Safety
+/// - `expression` must be a valid, non-null, null-terminated C string.
+/// - `ctx` must be a non-null pointer returned by `qcl_parse_ctx` (not yet freed).
+/// - The returned string must be freed via `qcl_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qcl_eval_ctx(expression: *const c_char, ctx: *const Val) -> *mut c_char {
+    if expression.is_null() {
+        return set_err("null expression pointer".to_string());
+    }
+    if ctx.is_null() {
+        return set_err("null ctx pointer".to_string());
+    }
+    let expr_str = match unsafe { CStr::from_ptr(expression) }.to_str() {
+        Ok(s) => s,
+        Err(e) => return set_err(format!("invalid expression UTF-8: {e}")),
+    };
+    // SAFETY: caller guarantees `ctx` is a live `Val` from `qcl_parse_ctx`.
+    let ctx_ref: &Val = unsafe { &*ctx };
+    eval_inner(expr_str, ctx_ref)
+}
+
+/// Check (truthy/falsy) a QCL expression against a pre-parsed context handle.
+/// Returns 1 for truthy, 0 for false/nil, -1 on error.
+///
+/// # Safety
+/// - `expression` and `ctx` must be valid, non-null; `ctx` from `qcl_parse_ctx`.
+#[cfg(feature = "json")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qcl_check_ctx(expression: *const c_char, ctx: *const Val) -> c_int {
+    if expression.is_null() {
+        set_err("null expression pointer".to_string());
+        return -1;
+    }
+    if ctx.is_null() {
+        set_err("null ctx pointer".to_string());
+        return -1;
+    }
+    let expr_str = match unsafe { CStr::from_ptr(expression) }.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_err(format!("invalid expression UTF-8: {e}"));
+            return -1;
+        }
+    };
+    // SAFETY: caller guarantees `ctx` is a live `Val` from `qcl_parse_ctx`.
+    let ctx_ref: &Val = unsafe { &*ctx };
+    let expr = match Expr::parse_cached_arc(expr_str) {
+        Ok(e) => e,
+        Err(e) => {
+            set_err(format!("{e}"));
+            return -1;
+        }
+    };
+    match expr.eval(ctx_ref) {
+        Ok(Val::Bool(true)) => 1,
+        Ok(Val::Bool(false) | Val::Nil) => 0,
+        Ok(_) => 1,
+        Err(e) => {
+            set_err(format!("{e}"));
+            -1
+        }
+    }
+}
+
+/// Free a context handle returned by `qcl_parse_ctx`.
+///
+/// # Safety
+/// `ctx` must be a pointer previously returned by `qcl_parse_ctx`, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qcl_free_ctx(ctx: *mut Val) {
+    if !ctx.is_null() {
+        // SAFETY: caller guarantees `ctx` was produced by `qcl_parse_ctx` and
+        // is not aliased / not previously freed.
+        drop(unsafe { Box::from_raw(ctx) });
+    }
+}
+
 /// Retrieve the last error message.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod expr;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod op;
+pub mod ser;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod token;
@@ -22,5 +23,6 @@ mod ast_test;
 mod de_test;
 mod expr_test;
 mod op_test;
+mod ser_test;
 mod token_test;
 mod val_test;

--- a/src/op.rs
+++ b/src/op.rs
@@ -10,8 +10,7 @@ use crate::{
 };
 
 const LARGE_LIST_MEMBERSHIP_THRESHOLD: usize = 16;
-const LIST_IN_LIST_INDEX_MIN_PROBES: usize = 32;
-const SINGLE_ITEM_INDEX_BUILD_THRESHOLD: usize = 1024;
+const LIST_IN_LIST_INDEX_MIN_PROBES: usize = 128;
 
 fn list_contains(list: &[Val], needle: &Val) -> bool {
     match needle {
@@ -195,15 +194,12 @@ impl BinOp {
                     Ok((**l).iter().all(|x| list_contains(r, x)))
                 }
 
-                // Single element membership
-                (_, Val::List(r)) => {
-                    if r.len() > SINGLE_ITEM_INDEX_BUILD_THRESHOLD {
-                        let index = MembershipIndex::new(r);
-                        return Ok(index.contains(l));
-                    }
-
-                    Ok(list_contains(r, l))
-                }
+                // Single element membership. A linear scan is always optimal
+                // here: a MembershipIndex costs O(n) up front (hashing every
+                // element) and only pays off across many lookups, but each `in`
+                // rebuilds it - so the indexed path was strictly slower than
+                // scanning for a single needle.
+                (_, Val::List(r)) => Ok(list_contains(r, l)),
 
                 // Map key membership: "key" in {"key": value}
                 (Val::Str(s), Val::Map(m)) => Ok(m.contains_key(s.as_ref())),

--- a/src/op_test.rs
+++ b/src/op_test.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn large_single_value_membership_uses_indexed_lookup() {
+    fn scalar_in_list_membership() {
         let haystack = Val::List(Arc::new((0..64).map(Val::Int).collect()));
 
         assert!(BinOp::In.cmp(&Val::Int(42), &haystack).unwrap());

--- a/src/python.rs
+++ b/src/python.rs
@@ -126,11 +126,55 @@ fn check(expression: &str, context: &Bound<'_, PyAny>) -> PyResult<bool> {
     Ok(!matches!(result, Val::Bool(false) | Val::Nil))
 }
 
+/// A pre-parsed QCL context, to amortize JSON parsing across many evaluations.
+///
+/// Build it once with `parse_ctx` and pass it to `eval_ctx` repeatedly:
+/// ```python
+/// ctx = qcl.parse_ctx(json_str)
+/// for expr in exprs:
+///     qcl.eval_ctx(expr, ctx)
+/// ```
+#[pyclass]
+struct Ctx {
+    val: Val,
+}
+
+/// Parse a JSON string into a `Ctx` handle for repeated evaluation.
+///
+/// Args:
+///     json_ctx: JSON string serving as the evaluation context
+///
+/// Returns:
+///     A `Ctx` that can be passed to `eval_ctx` any number of times.
+#[pyfunction]
+fn parse_ctx(json_ctx: &str) -> PyResult<Ctx> {
+    let val = de::from_json_str(json_ctx).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(Ctx { val })
+}
+
+/// Evaluate a QCL expression against a pre-parsed `Ctx`.
+///
+/// Args:
+///     expression: QCL expression string
+///     ctx: a `Ctx` returned by `parse_ctx`
+///
+/// Returns:
+///     The evaluation result as a Python object
+#[pyfunction]
+fn eval_ctx(py: Python<'_>, expression: &str, ctx: &Ctx) -> PyResult<PyObject> {
+    let expr = Expr::parse_cached_arc(expression).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let result = expr.eval(&ctx.val).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    val_to_py(py, &result, 0)
+}
+
 /// QCL Python module.
 #[pymodule]
 fn qcl(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(eval, m)?)?;
     m.add_function(wrap_pyfunction!(eval_json, m)?)?;
     m.add_function(wrap_pyfunction!(check, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_ctx, m)?)?;
+    m.add_function(wrap_pyfunction!(eval_ctx, m)?)?;
+    m.add_class::<Ctx>()?;
     Ok(())
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,351 @@
+//! Serialize a `serde::Serialize` value directly into a [`Val`], without a
+//! JSON text round-trip or an intermediate `serde_json::Value`.
+//!
+//! This mirrors [`crate::de::ValVisitor`] in the opposite direction: each
+//! `serialize_*` call builds the corresponding `Val` variant. It lets callers
+//! that already own a typed Rust value (struct, enum, `HashMap`, `Vec`) build
+//! a `Val` context in a single pass, avoiding both serialization-to-text and
+//! the double allocation of `serde_json::Value` -> `Val`.
+//!
+//! # Representation notes
+//! Because `Val` has no enum concept, serde enum variants are flattened:
+//! - unit variant `Foo::A` -> `Val::Str("A")`
+//! - newtype variant `Foo::A(x)` -> `Val::Map({"A": x})`
+//! - tuple/struct variants -> the inner sequence/map (variant name dropped)
+//! - `serialize_bytes` -> `Val::List` of ints
+
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::fmt;
+use hashbrown::HashMap;
+use serde::ser::{
+    Error as SerErrorTrait, Serialize, SerializeMap, SerializeSeq, SerializeStruct,
+    SerializeStructVariant, SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+    Serializer,
+};
+
+use crate::val::Val;
+
+/// Error raised while serializing into a `Val`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SerError(pub String);
+
+impl fmt::Display for SerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl SerError {
+    fn new(msg: impl Into<String>) -> Self {
+        SerError(msg.into())
+    }
+}
+
+impl SerErrorTrait for SerError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerError(msg.to_string())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SerError {}
+
+/// Serialize a `serde::Serialize` value into a [`Val`].
+///
+/// This is the single-pass alternative to `serde_json::to_value(value).into()`
+/// (which builds an intermediate `serde_json::Value` and then re-allocates
+/// every node into a `Val`).
+pub fn to_val<T: Serialize + ?Sized>(value: &T) -> Result<Val, SerError> {
+    value.serialize(&ValSerializer)
+}
+
+/// The serializer that builds a [`Val`].
+pub struct ValSerializer;
+
+impl Serializer for &ValSerializer {
+    type Ok = Val;
+    type Error = SerError;
+    type SerializeSeq = CompoundSeq;
+    type SerializeTuple = CompoundSeq;
+    type SerializeTupleStruct = CompoundSeq;
+    type SerializeTupleVariant = CompoundSeq;
+    type SerializeMap = CompoundMap;
+    type SerializeStruct = CompoundMap;
+    type SerializeStructVariant = CompoundMap;
+
+    fn serialize_bool(self, v: bool) -> Result<Val, SerError> {
+        Ok(Val::Bool(v))
+    }
+    fn serialize_i8(self, v: i8) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_i16(self, v: i16) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_i32(self, v: i32) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_i64(self, v: i64) -> Result<Val, SerError> {
+        Ok(Val::Int(v))
+    }
+    fn serialize_u8(self, v: u8) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_u16(self, v: u16) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_u32(self, v: u32) -> Result<Val, SerError> {
+        Ok(Val::Int(v as i64))
+    }
+    fn serialize_u64(self, v: u64) -> Result<Val, SerError> {
+        Ok(if v <= i64::MAX as u64 {
+            Val::Int(v as i64)
+        } else {
+            Val::Float(v as f64)
+        })
+    }
+    fn serialize_f32(self, v: f32) -> Result<Val, SerError> {
+        Ok(Val::Float(v as f64))
+    }
+    fn serialize_f64(self, v: f64) -> Result<Val, SerError> {
+        Ok(Val::Float(v))
+    }
+    fn serialize_char(self, c: char) -> Result<Val, SerError> {
+        let mut s = String::new();
+        s.push(c);
+        Ok(Val::Str(Arc::from(s)))
+    }
+    fn serialize_str(self, s: &str) -> Result<Val, SerError> {
+        Ok(Val::Str(Arc::from(s)))
+    }
+    fn serialize_bytes(self, b: &[u8]) -> Result<Val, SerError> {
+        let v: Vec<Val> = b.iter().map(|&x| Val::Int(x as i64)).collect();
+        Ok(Val::List(Arc::new(v)))
+    }
+    fn serialize_none(self) -> Result<Val, SerError> {
+        Ok(Val::Nil)
+    }
+    fn serialize_some<T: Serialize + ?Sized>(self, value: &T) -> Result<Val, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_unit(self) -> Result<Val, SerError> {
+        Ok(Val::Nil)
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Val, SerError> {
+        Ok(Val::Nil)
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+    ) -> Result<Val, SerError> {
+        Ok(Val::Str(Arc::from(variant)))
+    }
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Val, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Val, SerError> {
+        let inner = value.serialize(&ValSerializer)?;
+        let mut m = HashMap::with_capacity(1);
+        m.insert(variant.to_string(), inner);
+        Ok(Val::Map(Arc::new(m)))
+    }
+    fn serialize_seq(self, len: Option<usize>) -> Result<CompoundSeq, SerError> {
+        Ok(CompoundSeq {
+            elems: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+    fn serialize_tuple(self, len: usize) -> Result<CompoundSeq, SerError> {
+        Ok(CompoundSeq {
+            elems: Vec::with_capacity(len),
+        })
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<CompoundSeq, SerError> {
+        Ok(CompoundSeq {
+            elems: Vec::with_capacity(len),
+        })
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+        len: usize,
+    ) -> Result<CompoundSeq, SerError> {
+        Ok(CompoundSeq {
+            elems: Vec::with_capacity(len),
+        })
+    }
+    fn serialize_map(self, len: Option<usize>) -> Result<CompoundMap, SerError> {
+        Ok(CompoundMap {
+            map: HashMap::with_capacity(len.unwrap_or(0)),
+            next_key: None,
+        })
+    }
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<CompoundMap, SerError> {
+        Ok(CompoundMap {
+            map: HashMap::with_capacity(len),
+            next_key: None,
+        })
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _idx: u32,
+        _variant: &'static str,
+        len: usize,
+    ) -> Result<CompoundMap, SerError> {
+        Ok(CompoundMap {
+            map: HashMap::with_capacity(len),
+            next_key: None,
+        })
+    }
+}
+
+/// Builds a [`Val::List`] from a seq/tuple.
+pub struct CompoundSeq {
+    elems: Vec<Val>,
+}
+
+impl SerializeSeq for CompoundSeq {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SerError> {
+        self.elems.push(value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::List(Arc::new(self.elems)))
+    }
+}
+
+impl SerializeTuple for CompoundSeq {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SerError> {
+        self.elems.push(value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::List(Arc::new(self.elems)))
+    }
+}
+
+impl SerializeTupleStruct for CompoundSeq {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SerError> {
+        self.elems.push(value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::List(Arc::new(self.elems)))
+    }
+}
+
+impl SerializeTupleVariant for CompoundSeq {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SerError> {
+        self.elems.push(value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::List(Arc::new(self.elems)))
+    }
+}
+
+/// Builds a [`Val::Map`] from a map/struct.
+pub struct CompoundMap {
+    map: HashMap<String, Val>,
+    next_key: Option<String>,
+}
+
+impl CompoundMap {
+    /// Map keys must be string-valued (matching `Val::Map`), so a non-string
+    /// primitive is normalized to its string form, mirroring `Val::access`.
+    fn store_key(&mut self, key: Val) -> Result<(), SerError> {
+        let k = match key {
+            Val::Str(s) => s.to_string(),
+            Val::Int(i) => i.to_string(),
+            Val::Float(f) => f.to_string(),
+            Val::Bool(b) => b.to_string(),
+            _ => return Err(SerError::new("map key must be a primitive (str/int/float/bool)")),
+        };
+        self.next_key = Some(k);
+        Ok(())
+    }
+}
+
+impl SerializeMap for CompoundMap {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_key<T: Serialize + ?Sized>(&mut self, key: &T) -> Result<(), SerError> {
+        let key_val = key.serialize(&ValSerializer)?;
+        self.store_key(key_val)
+    }
+    fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SerError> {
+        let key = self
+            .next_key
+            .take()
+            .ok_or_else(|| SerError::new("serialize_value called without a matching serialize_key"))?;
+        self.map.insert(key, value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::Map(Arc::new(self.map)))
+    }
+}
+
+impl SerializeStruct for CompoundMap {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), SerError> {
+        self.map
+            .insert(key.to_string(), value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::Map(Arc::new(self.map)))
+    }
+}
+
+impl SerializeStructVariant for CompoundMap {
+    type Ok = Val;
+    type Error = SerError;
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), SerError> {
+        self.map
+            .insert(key.to_string(), value.serialize(&ValSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Val, SerError> {
+        Ok(Val::Map(Arc::new(self.map)))
+    }
+}

--- a/src/ser_test.rs
+++ b/src/ser_test.rs
@@ -1,0 +1,133 @@
+#[cfg(test)]
+mod tests {
+    use crate::ser::to_val;
+    use crate::val::Val;
+    use hashbrown::HashMap;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct User {
+        role: String,
+        age: i64,
+        admin: bool,
+    }
+
+    #[derive(Serialize)]
+    enum Shape {
+        Circle(f64),
+        Rect { w: f64, h: f64 },
+        Point,
+        Pair(i64, i64),
+    }
+
+    #[test]
+    fn primitives() {
+        assert_eq!(to_val(&true).unwrap(), Val::Bool(true));
+        assert_eq!(to_val(&42i64).unwrap(), Val::Int(42));
+        assert_eq!(to_val(&42u32).unwrap(), Val::Int(42));
+        assert_eq!(to_val(&u64::MAX).unwrap(), Val::Float(u64::MAX as f64));
+        assert_eq!(to_val(&3.14f64).unwrap(), Val::Float(3.14));
+        assert_eq!(to_val(&"hello").unwrap(), Val::Str("hello".into()));
+        assert_eq!(to_val(&'a').unwrap(), Val::Str("a".into()));
+        assert_eq!(to_val(&None::<i64>).unwrap(), Val::Nil);
+        assert_eq!(to_val(&Some(7i64)).unwrap(), Val::Int(7));
+        assert_eq!(to_val(&()).unwrap(), Val::Nil);
+    }
+
+    #[test]
+    fn list_and_map() {
+        let v = vec![1i64, 2, 3];
+        let val = to_val(&v).unwrap();
+        assert!(matches!(val, Val::List(l) if l.len() == 3));
+
+        let mut m = HashMap::new();
+        m.insert("k".to_string(), 1i64);
+        let val = to_val(&m).unwrap();
+        assert!(matches!(val, Val::Map(m) if m.len() == 1));
+    }
+
+    #[test]
+    fn struct_to_map() {
+        let u = User {
+            role: "admin".into(),
+            age: 18,
+            admin: true,
+        };
+        let val = to_val(&u).unwrap();
+        let m = match val {
+            Val::Map(m) => m,
+            _ => panic!("expected map"),
+        };
+        assert_eq!(m.len(), 3);
+        assert_eq!(m.get("role"), Some(&Val::Str("admin".into())));
+        assert_eq!(m.get("age"), Some(&Val::Int(18)));
+        assert_eq!(m.get("admin"), Some(&Val::Bool(true)));
+    }
+
+    #[test]
+    fn enum_variants() {
+        assert_eq!(to_val(&Shape::Point).unwrap(), Val::Str("Point".into()));
+
+        let newtype = to_val(&Shape::Circle(1.0)).unwrap();
+        match newtype {
+            Val::Map(m) => {
+                assert_eq!(m.len(), 1);
+                assert_eq!(m.get("Circle"), Some(&Val::Float(1.0)));
+            }
+            _ => panic!("expected map"),
+        }
+
+        let tuple = to_val(&Shape::Pair(1, 2)).unwrap();
+        assert!(matches!(tuple, Val::List(l) if l.len() == 2));
+
+        let st = to_val(&Shape::Rect { w: 2.0, h: 3.0 }).unwrap();
+        assert!(matches!(st, Val::Map(m) if m.len() == 2));
+    }
+
+    #[test]
+    fn nested_struct_in_vec() {
+        let v = vec![
+            User {
+                role: "a".into(),
+                age: 1,
+                admin: false,
+            },
+            User {
+                role: "b".into(),
+                age: 2,
+                admin: true,
+            },
+        ];
+        let val = to_val(&v).unwrap();
+        assert!(matches!(val, Val::List(l) if l.len() == 2));
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn matches_json_roundtrip() {
+        // to_val should produce the same Val as struct -> json text -> from_json_str,
+        // proving the serializer mirrors the deserializer's representation.
+        let u = User {
+            role: "admin".into(),
+            age: 18,
+            admin: true,
+        };
+        let direct = to_val(&u).unwrap();
+        let json = serde_json::to_string(&u).unwrap();
+        let via_json = crate::de::from_json_str(&json).unwrap();
+        assert_eq!(direct, via_json);
+    }
+
+    #[test]
+    fn try_from_uses_serializer() {
+        // Val::try_from now goes through ser::to_val (no serde_json::Value layer),
+        // so it works even without the `json` feature.
+        let u = User {
+            role: "admin".into(),
+            age: 18,
+            admin: true,
+        };
+        let v: Val = Val::try_from(&u).unwrap();
+        assert!(matches!(v, Val::Map(_)));
+    }
+}

--- a/src/ser_test.rs
+++ b/src/ser_test.rs
@@ -47,6 +47,32 @@ mod tests {
     }
 
     #[test]
+    fn map_with_int_key_normalizes_to_string() {
+        let mut m = HashMap::new();
+        m.insert(42i64, "answer");
+        let val = to_val(&m).unwrap();
+        match val {
+            Val::Map(m) => {
+                assert_eq!(m.len(), 1);
+                assert_eq!(m.get("42"), Some(&Val::Str("answer".into())));
+            }
+            _ => panic!("expected map"),
+        }
+    }
+
+    #[test]
+    fn map_with_non_primitive_key_errors() {
+        let mut m = HashMap::new();
+        m.insert((1i64, 2i64), "v");
+        let err = to_val(&m).unwrap_err();
+        assert!(
+            err.to_string().contains("map key must be a primitive"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
     fn struct_to_map() {
         let u = User {
             role: "admin".into(),

--- a/src/token.rs
+++ b/src/token.rs
@@ -254,24 +254,8 @@ impl<'a> Tokenizer<'a> {
                 't' => '\t',
                 '0' => '\0',
                 'u' => {
-                    self.idx += 1;
-                    if self.idx + 4 > self.len {
-                        return Err(Error::Tokenize(self.err("Invalid \\uXXXX escape, need 4 hex digits")));
-                    }
-                    // Validate on raw bytes first so the &str slice below is
-                    // guaranteed to land on a char boundary.
-                    let hb = &self.bytes[self.idx..self.idx + 4];
-                    if !hb.iter().all(|b| b.is_ascii_hexdigit()) {
-                        let shown = core::str::from_utf8(hb).unwrap_or("????");
-                        return Err(Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{shown}"))));
-                    }
-                    let hex = &self.input[self.idx..self.idx + 4];
-                    let code = u32::from_str_radix(hex, 16)
-                        .map_err(|_| Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{hex}"))))?;
-                    let ch = char::from_u32(code).ok_or_else(|| {
-                        Error::Tokenize(self.err(format!("Invalid unicode codepoint: \\u{hex}")))
-                    })?;
-                    self.idx += 4;
+                    self.idx += 1; // past 'u', to the first hex digit
+                    let ch = self.parse_unicode_escape()?;
                     s.push(ch);
                     continue;
                 }
@@ -285,6 +269,52 @@ impl<'a> Tokenizer<'a> {
             self.idx += 1; // escape letter is ASCII
         }
         Err(Error::Tokenize(self.err("String not closed")))
+    }
+
+    /// Parse a `\uXXXX` escape. On entry `self.idx` points at the first hex
+    /// digit (just past the `u`); on success it advances past the consumed
+    /// digits. A high surrogate immediately followed by a `\uXXXX` low surrogate
+    /// is combined into the supplementary code point; an unpaired or otherwise
+    /// invalid surrogate is rejected (mirroring `char::from_u32`).
+    fn parse_unicode_escape(&mut self) -> Result<char> {
+        if self.idx + 4 > self.len {
+            return Err(Error::Tokenize(self.err("Invalid \\uXXXX escape, need 4 hex digits")));
+        }
+        // Validate on raw bytes first so the &str slice below is guaranteed to
+        // land on a char boundary.
+        let hb = &self.bytes[self.idx..self.idx + 4];
+        if !hb.iter().all(|b| b.is_ascii_hexdigit()) {
+            let shown = core::str::from_utf8(hb).unwrap_or("????");
+            return Err(Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{shown}"))));
+        }
+        let hex = &self.input[self.idx..self.idx + 4];
+        let code = u32::from_str_radix(hex, 16)
+            .map_err(|_| Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{hex}"))))?;
+        self.idx += 4;
+
+        // High surrogate: combine with an immediately following `\uXXXX` low
+        // surrogate into the supplementary code point.
+        if (0xD800..=0xDBFF).contains(&code)
+            && self.idx + 6 <= self.len
+            && self.bytes[self.idx] == b'\\'
+            && self.bytes[self.idx + 1] == b'u'
+        {
+            let lb = &self.bytes[self.idx + 2..self.idx + 6];
+            if lb.iter().all(|b| b.is_ascii_hexdigit()) {
+                let lhex = &self.input[self.idx + 2..self.idx + 6];
+                if let Ok(low) = u32::from_str_radix(lhex, 16) {
+                    if (0xDC00..=0xDFFF).contains(&low) {
+                        self.idx += 6; // consume the second `\uXXXX`
+                        let combined = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+                        // A well-formed surrogate pair always yields a scalar.
+                        return Ok(char::from_u32(combined).unwrap());
+                    }
+                }
+            }
+        }
+        // BMP scalar, or an unpaired/invalid surrogate (rejected by from_u32).
+        char::from_u32(code)
+            .ok_or_else(|| Error::Tokenize(self.err(format!("Invalid unicode codepoint: \\u{hex}"))))
     }
 
     /// Check whether a sign (+/-) should be treated as the start of a numeric literal

--- a/src/token.rs
+++ b/src/token.rs
@@ -191,71 +191,99 @@ impl<'a> Tokenizer<'a> {
     }
 
     fn parse_str(&mut self) -> Result<()> {
-        let mut s = String::new();
-        let quote = self.cur_char().unwrap(); // ' or " (ASCII)
-        self.idx += 1;
+        let quote_byte = self.cur_byte(); // ' or " (ASCII)
+        let content_start = self.idx + 1; // skip opening quote
+        self.idx = content_start;
+
+        // Fast path: scan byte-by-byte for the closing quote or a backslash.
+        // Both are ASCII (< 0x80), so they never appear inside a multibyte
+        // UTF-8 sequence; advancing one byte at a time is safe, and the slice
+        // below lands on char boundaries (opening + closing quotes are ASCII).
+        // The common case (no escapes) then needs zero allocation and no
+        // per-char push - the string is sliced straight out of the input.
+        while !self.eof() {
+            let b = self.cur_byte();
+            if b == quote_byte {
+                let s = &self.input[content_start..self.idx];
+                self.idx += 1;
+                self.tokens.push(Token::Str(Arc::<str>::from(s)));
+                return Ok(());
+            }
+            if b == b'\\' {
+                return self.parse_str_slow(content_start);
+            }
+            self.idx += 1;
+        }
+        Err(Error::Tokenize(self.err("String not closed")))
+    }
+
+    /// Slow path for string literals containing escapes. `content_start` is the
+    /// byte offset just after the opening quote; `[content_start, self.idx)`
+    /// has already been scanned and is escape-free, so it seeds the `String`
+    /// without re-pushing char by char.
+    fn parse_str_slow(&mut self, content_start: usize) -> Result<()> {
+        let quote_byte = self.bytes[content_start - 1]; // opening quote
+        let mut s = String::from(&self.input[content_start..self.idx]);
 
         while !self.eof() {
-            let c = self.cur_char().unwrap();
-            match c {
-                '\\' => {
-                    self.idx += 1;
-                    if self.eof() {
-                        return Err(Error::Tokenize(self.err("Invalid escape sequence")));
-                    }
-
-                    let next = self.cur_char().unwrap();
-                    let escaped = match next {
-                        '\\' => '\\',
-                        '"' => '"',
-                        '\'' => '\'',
-                        'n' => '\n',
-                        'r' => '\r',
-                        't' => '\t',
-                        '0' => '\0',
-                        'u' => {
-                            self.idx += 1;
-                            if self.idx + 4 > self.len {
-                                return Err(Error::Tokenize(self.err("Invalid \\uXXXX escape, need 4 hex digits")));
-                            }
-                            // Validate on raw bytes first so the &str slice below is
-                            // guaranteed to land on a char boundary.
-                            let hb = &self.bytes[self.idx..self.idx + 4];
-                            if !hb.iter().all(|b| b.is_ascii_hexdigit()) {
-                                let shown = core::str::from_utf8(hb).unwrap_or("????");
-                                return Err(Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{shown}"))));
-                            }
-                            let hex = &self.input[self.idx..self.idx + 4];
-                            let code = u32::from_str_radix(hex, 16)
-                                .map_err(|_| Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{hex}"))))?;
-                            let ch = char::from_u32(code).ok_or_else(|| {
-                                Error::Tokenize(self.err(format!("Invalid unicode codepoint: \\u{hex}")))
-                            })?;
-                            self.idx += 4;
-                            s.push(ch);
-                            continue;
-                        }
-                        other => {
-                            return Err(Error::Tokenize(
-                                self.err(format!("Unsupported escape sequence: \\{other}")),
-                            ));
-                        }
-                    };
-                    s.push(escaped);
-                    self.idx += 1; // escape letter is ASCII
-                }
-                c if c == quote => {
-                    self.idx += 1;
-                    self.tokens.push(Token::Str(Arc::<str>::from(s)));
-                    return Ok(());
-                }
-                _ => {
-                    s.push(c);
-                    self.idx += c.len_utf8();
-                }
+            let b = self.cur_byte();
+            if b == quote_byte {
+                self.idx += 1;
+                self.tokens.push(Token::Str(Arc::<str>::from(s)));
+                return Ok(());
             }
-        }
+            if b != b'\\' {
+                let c = self.cur_char().unwrap();
+                s.push(c);
+                self.idx += c.len_utf8();
+                continue;
+            }
 
+            // backslash escape
+            self.idx += 1;
+            if self.eof() {
+                return Err(Error::Tokenize(self.err("Invalid escape sequence")));
+            }
+            let next = self.cur_char().unwrap();
+            let escaped = match next {
+                '\\' => '\\',
+                '"' => '"',
+                '\'' => '\'',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                '0' => '\0',
+                'u' => {
+                    self.idx += 1;
+                    if self.idx + 4 > self.len {
+                        return Err(Error::Tokenize(self.err("Invalid \\uXXXX escape, need 4 hex digits")));
+                    }
+                    // Validate on raw bytes first so the &str slice below is
+                    // guaranteed to land on a char boundary.
+                    let hb = &self.bytes[self.idx..self.idx + 4];
+                    if !hb.iter().all(|b| b.is_ascii_hexdigit()) {
+                        let shown = core::str::from_utf8(hb).unwrap_or("????");
+                        return Err(Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{shown}"))));
+                    }
+                    let hex = &self.input[self.idx..self.idx + 4];
+                    let code = u32::from_str_radix(hex, 16)
+                        .map_err(|_| Error::Tokenize(self.err(format!("Invalid unicode escape: \\u{hex}"))))?;
+                    let ch = char::from_u32(code).ok_or_else(|| {
+                        Error::Tokenize(self.err(format!("Invalid unicode codepoint: \\u{hex}")))
+                    })?;
+                    self.idx += 4;
+                    s.push(ch);
+                    continue;
+                }
+                other => {
+                    return Err(Error::Tokenize(
+                        self.err(format!("Unsupported escape sequence: \\{other}")),
+                    ));
+                }
+            };
+            s.push(escaped);
+            self.idx += 1; // escape letter is ASCII
+        }
         Err(Error::Tokenize(self.err("String not closed")))
     }
 

--- a/src/token_test.rs
+++ b/src/token_test.rs
@@ -719,6 +719,21 @@ mod tests {
     }
 
     #[test]
+    fn test_unicode_surrogate_pair() {
+        // A high surrogate followed by a low surrogate combines into the
+        // supplementary code point (U+1F600).
+        let t = Tokenizer::new("\"\\uD83D\\uDE00\"");
+        assert_eq!(t.unwrap(), vec![str_token("😀")]);
+
+        // Unpaired high surrogate is rejected.
+        assert!(Tokenizer::new(r#""\uD83D""#).is_err());
+        // Unpaired low surrogate is rejected.
+        assert!(Tokenizer::new(r#""\uDC00""#).is_err());
+        // High surrogate followed by a non-`\u` sequence is rejected.
+        assert!(Tokenizer::new(r#""\uD83Dx""#).is_err());
+    }
+
+    #[test]
     fn test_error_location() {
         let err = Tokenizer::new("1 + ^").unwrap_err();
         let msg = err.to_string();

--- a/src/val.rs
+++ b/src/val.rs
@@ -589,7 +589,7 @@ impl Val {
     /// `serde_json::to_value` would build. Available on all features (no longer
     /// gated behind `json`), since it only depends on `serde`.
     pub fn try_from<T: serde::Serialize>(val: T) -> Result<Self> {
-        crate::ser::to_val(&val).map_err(|e| Error::Deserialize(e.to_string()))
+        Self::from_serialize(&val)
     }
 
     /// Construct a `Val` from any `serde::Serialize` value in a single pass.

--- a/src/val.rs
+++ b/src/val.rs
@@ -584,14 +584,18 @@ fn yaml_value_to_val(val: serde_yaml::Value, depth: usize) -> Val {
 }
 
 impl Val {
-    #[cfg(feature = "json")]
-    pub fn try_from<T>(val: T) -> Result<Self>
-    where
-        T: serde::Serialize,
-    {
-        Ok(serde_json::to_value(val)
-            .map_err(|e| Error::Eval(e.to_string()))?
-            .into())
+    /// Convert any `serde::Serialize` value into a `Val` directly, without a
+    /// JSON text round-trip or the intermediate `serde_json::Value` that
+    /// `serde_json::to_value` would build. Available on all features (no longer
+    /// gated behind `json`), since it only depends on `serde`.
+    pub fn try_from<T: serde::Serialize>(val: T) -> Result<Self> {
+        crate::ser::to_val(&val).map_err(|e| Error::Deserialize(e.to_string()))
+    }
+
+    /// Construct a `Val` from any `serde::Serialize` value in a single pass.
+    /// See [`crate::ser`] for the representation rules (e.g. enum variants).
+    pub fn from_serialize<T: serde::Serialize + ?Sized>(value: &T) -> Result<Self> {
+        crate::ser::to_val(value).map_err(|e| Error::Deserialize(e.to_string()))
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,18 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use once_cell::sync::Lazy;
 use wasm_bindgen::prelude::*;
 
 use crate::{de, expr::Expr, val::Val};
+
+/// Monotonic handle id for pre-parsed contexts (0 is reserved as "invalid").
+static NEXT_HANDLE: AtomicU32 = AtomicU32::new(1);
+/// Live pre-parsed contexts, keyed by handle id. Lets a JSON context be parsed
+/// once and shared across many `eval_ctx` calls without re-parsing.
+static CTX_TABLE: Lazy<Mutex<HashMap<u32, Arc<Val>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Evaluate a QCL expression against a JSON context string.
 ///
@@ -23,4 +35,36 @@ pub fn eval(expression: &str, ctx: JsValue) -> Result<JsValue, JsError> {
     let expr = Expr::parse_cached_arc(expression).map_err(|e| JsError::new(&e.to_string()))?;
     let result = expr.eval(&ctx).map_err(|e| JsError::new(&e.to_string()))?;
     serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Parse a JSON context string into an opaque handle for repeated evaluation.
+/// Returns a non-zero handle id; pass it to `eval_ctx` any number of times and
+/// release it with `free_ctx` when done.
+#[wasm_bindgen]
+pub fn parse_ctx(json_ctx: &str) -> Result<u32, JsError> {
+    let val = de::from_json_str(json_ctx).map_err(|e| JsError::new(&e.to_string()))?;
+    let id = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
+    CTX_TABLE.lock().unwrap().insert(id, Arc::new(val));
+    Ok(id)
+}
+
+/// Evaluate a QCL expression against a pre-parsed context handle.
+#[wasm_bindgen]
+pub fn eval_ctx(expression: &str, handle: u32) -> Result<JsValue, JsError> {
+    let ctx = CTX_TABLE
+        .lock()
+        .unwrap()
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| JsError::new("invalid or freed ctx handle"))?;
+    let expr = Expr::parse_cached_arc(expression).map_err(|e| JsError::new(&e.to_string()))?;
+    let result = expr.eval(&ctx).map_err(|e| JsError::new(&e.to_string()))?;
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Release a context handle returned by `parse_ctx`. After this the handle is
+/// invalid and must not be used again.
+#[wasm_bindgen]
+pub fn free_ctx(handle: u32) {
+    CTX_TABLE.lock().unwrap().remove(&handle);
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -43,9 +43,22 @@ pub fn eval(expression: &str, ctx: JsValue) -> Result<JsValue, JsError> {
 #[wasm_bindgen]
 pub fn parse_ctx(json_ctx: &str) -> Result<u32, JsError> {
     let val = de::from_json_str(json_ctx).map_err(|e| JsError::new(&e.to_string()))?;
-    let id = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
-    CTX_TABLE.lock().unwrap().insert(id, Arc::new(val));
+    let arc = Arc::new(val);
+    let mut table = CTX_TABLE.lock().unwrap();
+    let id = alloc_handle(&table);
+    table.insert(id, arc);
     Ok(id)
+}
+
+/// Allocate a handle id, skipping the reserved 0 and any id still live in the
+/// table so that counter wraparound can never silently evict a live context.
+fn alloc_handle(table: &HashMap<u32, Arc<Val>>) -> u32 {
+    loop {
+        let id = NEXT_HANDLE.fetch_add(1, Ordering::Relaxed);
+        if id != 0 && !table.contains_key(&id) {
+            return id;
+        }
+    }
 }
 
 /// Evaluate a QCL expression against a pre-parsed context handle.


### PR DESCRIPTION
## 背景

端到端实测:JSON context 解析占请求总耗时 **91–98%**(小 ctx 204B: 1080ns/1184ns;大 ctx 7KB: 13.8µs/14.1µs),qcl 的 parse+eval+format 合计仅 2–9%。瓶颈在解析,不在 eval。

## 改动

- **Val 反向 Serializer** (`src/ser.rs`, 新增): `Serialize -> Val` 单遍构造,免去 `serde_json::Value` 中间层(原 `Val::try_from` 走 `serde_json::to_value` 双倍分配)。`try_from` 改走此路径,全 feature 可用(不再 gate `json`)。新增 `Val::from_serialize`。
- **顶层字段剪裁** (`src/de.rs`): `from_json_str_keep` / `from_json_str_for_exprs` 用 `Expr::requested_ctx` 跳过未引用的顶层 key(`IgnoredAny`,不构造 Val),减少大 ctx 的解析+分配。深层全解析;空 keep / 非 object 时全解析保安全。
- **复用 Val context** (ffi/wasm/python): parse-once 句柄,摊薄 JSON 解析到多次 eval。
  - FFI: `qcl_parse_ctx` / `qcl_eval_ctx` / `qcl_check_ctx` / `qcl_free_ctx`(opaque `*mut Val`)
  - WASM: `parse_ctx` / `eval_ctx` / `free_ctx`(u32 句柄表)
  - Python: `#[pyclass] Ctx` + `parse_ctx` / `eval_ctx`(GC 管理)
- **benchmark**: `parse_with_cache` 改用 `parse_cached_arc`(修 355ns AST 深拷贝假象,反映真实 ~23ns cache hit)+ 新增 `bench_context_parsing`(ctx_parse full/filtered + e2e pipeline)。
- **expr/op/token**: parse cache per-shard clock、`in` 单元素线性扫描、字符串字面量零拷贝快路径。

## 否决

- **sonic-rs**: 实测 aarch64 无收益(大 JSON 反慢 3%),且 `Val` 构造比 `serde_json::Value` 还快 12%--parser 非瓶颈,放弃。

## 验证

- `cargo test`: 196 passed
- `cargo check --features wasm,ffi,python`: 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct conversion from serializable values into QCL values.
  - Added reusable parsed-context APIs for Python, C, and WebAssembly integrations.
  - Added JSON context filtering to parse only keys needed by selected expressions.
- **Performance**
  - Improved repeated expression parsing and context evaluation efficiency.
  - Optimized string parsing and list membership checks.
- **Bug Fixes**
  - Preserved expected behavior for filtered, empty, and non-object JSON contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->